### PR TITLE
fix: mark 34 README-verified flat mods as root-extraction

### DIFF
--- a/docs/superpowers/plans/2026-07-06-catalog-v2.md
+++ b/docs/superpowers/plans/2026-07-06-catalog-v2.md
@@ -1,0 +1,876 @@
+# Catalog v2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend quickfix's `mods.json` with auto-derived fields (`wine_dll_override`, `loader`, `zip_layout`, `derived_release`, `download_url`, `sha256`, `size`, per-game `install_subdir`) so the decky-lyall plugin can install fixes safely on SteamOS.
+
+**Architecture:** A new `scripts/derive_mod_metadata.py` runs in the existing `refresh-mods.yml` workflow after `update_mods.py`, downloading each mod's latest release zip once per new tag and deriving metadata from its contents. `update_mods.py` is fixed to preserve fields it doesn't own (today it strips them). `validate_mods.py` learns the new fields and stops hard-failing on empty `games[]` (which is currently broken: `DOAXVVPrismFix` and `NoSleepForKanameDateFix` have empty `games[]` in master's mods.json, so any mods.json PR fails validation today).
+
+**Tech Stack:** Python 3.11, pytest, requests, GitHub Actions. Repo: `/config/quickfix`. Work on branch `feat/catalog-v2`.
+
+**Spec:** `docs/superpowers/specs/2026-07-06-decky-quickfix-plugin-design.md` (Part 1).
+
+---
+
+### Task 0: Branch + pytest scaffolding
+
+**Files:**
+- Create: `conftest.py`, `tests/__init__.py` (empty)
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+cd /config/quickfix && git switch -c feat/catalog-v2
+```
+
+- [ ] **Step 2: Add import shim so tests can import scripts/**
+
+`conftest.py` (repo root):
+
+```python
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "scripts"))
+```
+
+Create empty `tests/__init__.py`.
+
+- [ ] **Step 3: Verify pytest runs (collects nothing, exits 5 or 0)**
+
+Run: `cd /config/quickfix && python3 -m pytest -q`
+Expected: `no tests ran` (exit code 5 is fine at this point).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add conftest.py tests/__init__.py
+git commit -m "test: add pytest scaffolding"
+```
+
+---
+
+### Task 1: Fix `update_mods.py` stripping unknown fields
+
+Today lines 203–223 rebuild every existing entry with exactly four keys and replace the entry whenever the rebuilt dict differs — once derived fields exist, that strips them on every run and silently forces full re-derivation (~100 zip downloads) every 6 hours.
+
+**Files:**
+- Modify: `scripts/update_mods.py:203-223`
+- Test: `tests/test_update_mods.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/test_update_mods.py`:
+
+```python
+from update_mods import refresh_existing_entry
+
+
+def _entry():
+    return {
+        "repo": "Lyall/FooFix",
+        "config_files": ["FooFix.ini"],
+        "games": [{"steam_appid": 1, "install_subdir": "Foo/Binaries/Win64"}],
+        "last_updated": "old",
+        "wine_dll_override": "dsound",
+        "loader": "ual",
+        "zip_layout": "flat",
+        "derived_release": "0.0.1",
+        "download_url": "https://codeberg.org/Lyall/FooFix/releases/download/0.0.1/FooFix_0.0.1.zip",
+        "sha256": "a" * 64,
+        "size": 123,
+    }
+
+
+def test_refresh_preserves_derived_fields():
+    existing = _entry()
+    out = refresh_existing_entry(existing, "Lyall/FooFix", "new-timestamp")
+    assert out["last_updated"] == "new-timestamp"
+    assert out["wine_dll_override"] == "dsound"
+    assert out["sha256"] == "a" * 64
+    assert out["games"][0]["install_subdir"] == "Foo/Binaries/Win64"
+
+
+def test_refresh_does_not_mutate_input():
+    existing = _entry()
+    refresh_existing_entry(existing, "Lyall/FooFix", "new-timestamp")
+    assert existing["last_updated"] == "old"
+
+
+def test_refresh_unchanged_when_timestamp_same():
+    existing = _entry()
+    out = refresh_existing_entry(existing, "Lyall/FooFix", "old")
+    assert out == existing
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python3 -m pytest tests/test_update_mods.py -v`
+Expected: FAIL — `ImportError: cannot import name 'refresh_existing_entry'`.
+
+- [ ] **Step 3: Implement**
+
+In `scripts/update_mods.py`, add after `load_existing_mods()`:
+
+```python
+def refresh_existing_entry(existing_entry, full_name, repo_updated_at):
+    """Update only the fields this script owns, preserving derived/unknown fields."""
+    new_entry = copy.deepcopy(existing_entry)
+    new_entry["repo"] = full_name
+    new_entry["last_updated"] = repo_updated_at
+    return new_entry
+```
+
+Replace the whole `else:` branch of the existing-mod path (currently lines 203–223, starting `print(f"✏️ Existing mod: {mod_id}")` and ending `updated_mods[mod_id] = existing_mods[mod_id]`) with:
+
+```python
+            else:
+                print(f"✏️ Existing mod: {mod_id}")
+                new_entry = refresh_existing_entry(existing_mods[mod_id], full_name, repo_updated_at)
+                if new_entry != existing_mods[mod_id]:
+                    print(f"✏️ Updated mod: {mod_id} (last updated: {repo_updated_at})")
+                    updated_mods[mod_id] = new_entry
+                    updated_mods_ids.append(mod_id)
+                else:
+                    updated_mods[mod_id] = existing_mods[mod_id]
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python3 -m pytest tests/test_update_mods.py -v`
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/update_mods.py tests/test_update_mods.py
+git commit -m "fix: update_mods preserves derived fields on refresh"
+```
+
+---
+
+### Task 2: `analyze_zip` — derive metadata from zip entry names
+
+**Files:**
+- Create: `scripts/derive_mod_metadata.py`
+- Test: `tests/test_derive_mod_metadata.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_derive_mod_metadata.py`:
+
+```python
+from derive_mod_metadata import analyze_zip
+
+
+def test_flat_ual_zip():
+    names = ["ClairObscurFix.asi", "ClairObscurFix.ini", "dsound.dll", "EXTRACT_TO_GAME_FOLDER"]
+    meta = analyze_zip(names)
+    assert meta == {"wine_dll_override": "dsound", "loader": "ual", "zip_layout": "flat"}
+
+
+def test_pathed_ual_zip():
+    names = ["End/Binaries/Win64/dsound.dll", "End/Binaries/Win64/FF7RebirthFix.asi",
+             "End/Binaries/Win64/FF7RebirthFix.ini"]
+    meta = analyze_zip(names)
+    assert meta == {"wine_dll_override": "dsound", "loader": "ual", "zip_layout": "pathed"}
+
+
+def test_backslash_entries_are_normalized():
+    names = ["End\\Binaries\\Win64\\dsound.dll", "End\\Binaries\\Win64\\Fix.asi"]
+    meta = analyze_zip(names)
+    assert meta["wine_dll_override"] == "dsound"
+    assert meta["zip_layout"] == "pathed"
+
+
+def test_bepinex_zip_prefers_shallowest_proxy_dll():
+    # dotnet runtime ships deep DLLs that shadow proxy names; depth breaks the tie
+    names = ["winhttp.dll", "doorstop_config.ini", "BepInEx/core/BepInEx.dll",
+             "dotnet/shared/version.dll"]
+    meta = analyze_zip(names)
+    assert meta == {"wine_dll_override": "winhttp", "loader": "bepinex", "zip_layout": "pathed"}
+
+
+def test_melonloader_zip():
+    names = ["version.dll", "MelonLoader/net6/MelonLoader.dll", "Mods/SyberiaTWBFix.dll"]
+    meta = analyze_zip(names)
+    assert meta["loader"] == "melonloader"
+    assert meta["wine_dll_override"] == "version"
+
+
+def test_no_known_proxy_dll_yields_none():
+    names = ["Fix.asi", "dxgi.dll"]  # dxgi is deliberately excluded (DXVK conflict)
+    assert analyze_zip(names)["wine_dll_override"] is None
+
+
+def test_ambiguous_proxies_at_same_depth_yield_none():
+    names = ["dsound.dll", "winmm.dll", "Fix.asi"]
+    assert analyze_zip(names)["wine_dll_override"] is None
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/test_derive_mod_metadata.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+`scripts/derive_mod_metadata.py`:
+
+```python
+import argparse
+import hashlib
+import io
+import json
+import os
+import zipfile
+
+import requests
+
+CODEBERG_API = "https://codeberg.org/api/v1"
+
+# UAL x64 proxy names Lyall's fixes can ship. dxgi is deliberately excluded:
+# auto-overriding it would break DXVK.
+KNOWN_PROXY_DLLS = frozenset({
+    "dsound", "winmm", "dinput8", "version", "winhttp",
+    "wininet", "d3d9", "d3d10", "d3d11", "d3d12",
+    "xinput1_1", "xinput1_2", "xinput1_3", "xinput1_4",
+    "xinput9_1_0", "xinputuap", "binkw64", "bink2w64",
+})
+
+DERIVED_FIELDS = ("wine_dll_override", "loader", "zip_layout", "download_url", "sha256", "size")
+
+
+def analyze_zip(names):
+    """Derive {wine_dll_override, loader, zip_layout} from zip entry names."""
+    norm = [n.replace("\\", "/").lstrip("/") for n in names]
+    payload = [n for n in norm
+               if n and not n.endswith("/")
+               and os.path.basename(n) != "EXTRACT_TO_GAME_FOLDER"]
+
+    top_dirs = {n.split("/", 1)[0] for n in payload if "/" in n}
+    if "BepInEx" in top_dirs:
+        loader = "bepinex"
+    elif "MelonLoader" in top_dirs:
+        loader = "melonloader"
+    else:
+        loader = "ual"
+
+    candidates = []
+    for n in payload:
+        base = os.path.basename(n).lower()
+        if base.endswith(".dll") and base[:-4] in KNOWN_PROXY_DLLS:
+            candidates.append((n.count("/"), base[:-4]))
+
+    override = None
+    if candidates:
+        min_depth = min(depth for depth, _ in candidates)
+        at_min = {stem for depth, stem in candidates if depth == min_depth}
+        if len(at_min) == 1:
+            override = at_min.pop()
+
+    zip_layout = "pathed" if any("/" in n for n in payload) else "flat"
+    return {"wine_dll_override": override, "loader": loader, "zip_layout": zip_layout}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python3 -m pytest tests/test_derive_mod_metadata.py -v`
+Expected: 7 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/derive_mod_metadata.py tests/test_derive_mod_metadata.py
+git commit -m "feat: analyze_zip derives override/loader/layout from zip entries"
+```
+
+---
+
+### Task 3: Derivation orchestration, hashing, and curation warnings
+
+**Files:**
+- Modify: `scripts/derive_mod_metadata.py`
+- Test: `tests/test_derive_mod_metadata.py` (append)
+
+- [ ] **Step 1: Write the failing tests** (append to `tests/test_derive_mod_metadata.py`)
+
+```python
+import hashlib
+import io
+import zipfile
+
+from derive_mod_metadata import collect_warnings, derive_mod, needs_derivation
+
+
+def _zip_blob(names):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for n in names:
+            zf.writestr(n, b"x")
+    return buf.getvalue()
+
+
+def test_needs_derivation_on_new_tag_or_missing_fields():
+    mod = {"derived_release": "0.0.1", "wine_dll_override": "dsound", "loader": "ual",
+           "zip_layout": "flat", "download_url": "u", "sha256": "s", "size": 1}
+    assert not needs_derivation(mod, "0.0.1")
+    assert needs_derivation(mod, "0.0.2")
+    del mod["sha256"]
+    assert needs_derivation(mod, "0.0.1")
+
+
+def test_derive_mod_sets_all_fields():
+    blob = _zip_blob(["Fix.asi", "dsound.dll", "Fix.ini"])
+    mod = {"repo": "Lyall/Fix", "games": [{"steam_appid": 1}]}
+    derive_mod(mod, {"tag": "0.0.5", "url": "https://codeberg.org/x/Fix.zip"}, blob)
+    assert mod["wine_dll_override"] == "dsound"
+    assert mod["zip_layout"] == "flat"
+    assert mod["derived_release"] == "0.0.5"
+    assert mod["download_url"] == "https://codeberg.org/x/Fix.zip"
+    assert mod["sha256"] == hashlib.sha256(blob).hexdigest()
+    assert mod["size"] == len(blob)
+
+
+def test_derive_mod_keeps_old_override_when_underivable():
+    blob = _zip_blob(["Fix.asi"])  # no proxy DLL found
+    mod = {"repo": "Lyall/Fix", "wine_dll_override": "winmm", "games": []}
+    derive_mod(mod, {"tag": "0.0.6", "url": "u"}, blob)
+    assert mod["wine_dll_override"] == "winmm"  # not clobbered with None
+
+
+def test_collect_warnings():
+    mods = {
+        "NoOverride": {"games": [{"steam_appid": 1}], "zip_layout": "pathed"},
+        "FlatNoSubdir": {"wine_dll_override": "dsound", "zip_layout": "flat",
+                          "games": [{"steam_appid": 2}]},
+        "Empty": {"wine_dll_override": "dsound", "zip_layout": "pathed", "games": []},
+        "DupA": {"wine_dll_override": "dsound", "zip_layout": "pathed",
+                 "games": [{"steam_appid": 3}]},
+        "DupB": {"wine_dll_override": "dsound", "zip_layout": "pathed",
+                 "games": [{"steam_appid": 3}]},
+    }
+    warnings = collect_warnings(mods)
+    text = "\n".join(warnings)
+    assert "NoOverride" in text and "wine_dll_override" in text
+    assert "FlatNoSubdir" in text and "install_subdir" in text
+    assert "Empty" in text and "games" in text
+    assert "DupA" in text and "DupB" in text
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/test_derive_mod_metadata.py -v`
+Expected: new tests FAIL (names not defined); Task 2 tests still PASS.
+
+- [ ] **Step 3: Implement** (append to `scripts/derive_mod_metadata.py`)
+
+```python
+def codeberg_get(url):
+    headers = {}
+    token = os.environ.get("CODEBERG_TOKEN")
+    if token:
+        headers["Authorization"] = f"token {token}"
+    return requests.get(url, headers=headers, timeout=15)
+
+
+def get_latest_zip_asset(repo):
+    """Return {'tag', 'url'} for the latest release's .zip asset, or None."""
+    resp = codeberg_get(f"{CODEBERG_API}/repos/{repo}/releases/latest")
+    if resp.status_code != 200:
+        return None
+    data = resp.json()
+    for asset in data.get("assets", []):
+        if asset.get("name", "").endswith(".zip"):
+            return {"tag": data.get("tag_name", ""), "url": asset["browser_download_url"]}
+    return None
+
+
+def download(url):
+    resp = requests.get(url, timeout=60)
+    resp.raise_for_status()
+    return resp.content
+
+
+def needs_derivation(mod, tag):
+    if mod.get("derived_release") != tag:
+        return True
+    return not all(mod.get(f) for f in DERIVED_FIELDS)
+
+
+def derive_mod(mod, release, blob):
+    """Derive and set metadata fields on mod, in place. install_subdir is never touched."""
+    meta = analyze_zip(zipfile.ZipFile(io.BytesIO(blob)).namelist())
+    mod["loader"] = meta["loader"]
+    mod["zip_layout"] = meta["zip_layout"]
+    if meta["wine_dll_override"]:
+        mod["wine_dll_override"] = meta["wine_dll_override"]
+    mod["download_url"] = release["url"]
+    mod["sha256"] = hashlib.sha256(blob).hexdigest()
+    mod["size"] = len(blob)
+    mod["derived_release"] = release["tag"]
+
+
+def collect_warnings(mods):
+    warnings = []
+    seen_appids = {}
+    for mod_id, mod in mods.items():
+        if not mod.get("wine_dll_override"):
+            warnings.append(f"`{mod_id}`: no `wine_dll_override` derived — invisible on Deck until set")
+        if not mod.get("games"):
+            warnings.append(f"`{mod_id}`: empty `games[]` — needs a Steam appid")
+        for game in mod.get("games", []):
+            appid = game.get("steam_appid")
+            if mod.get("zip_layout") == "flat" and not game.get("install_subdir"):
+                warnings.append(f"`{mod_id}`: flat zip but appid {appid} has no `install_subdir` — installs blocked on Deck")
+            if appid in seen_appids and seen_appids[appid] != mod_id:
+                warnings.append(f"appid {appid} claimed by both `{seen_appids[appid]}` and `{mod_id}`")
+            seen_appids.setdefault(appid, mod_id)
+    return warnings
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Derive mod metadata from release zips")
+    parser.add_argument("--only", nargs="*", help="Limit to these mod ids (for local smoke runs)")
+    args = parser.parse_args()
+
+    with open("mods.json", "r", encoding="utf-8") as f:
+        mods = json.load(f)
+
+    changed = False
+    for mod_id, mod in mods.items():
+        if args.only and mod_id not in args.only:
+            continue
+        release = get_latest_zip_asset(mod["repo"])
+        if release is None:
+            print(f"⚠️ {mod_id}: no release with a .zip asset")
+            continue
+        if needs_derivation(mod, release["tag"]):
+            print(f"🔬 Deriving {mod_id} @ {release['tag']}")
+            try:
+                blob = download(release["url"])
+            except Exception as e:
+                print(f"⚠️ {mod_id}: download failed: {e}")
+                continue
+            derive_mod(mod, release, blob)
+            changed = True
+        else:
+            print(f"✅ {mod_id}: up to date ({release['tag']})")
+
+    if changed:
+        with open("mods.json", "w", encoding="utf-8") as f:
+            json.dump(mods, f, indent=2, ensure_ascii=False)
+        print("✅ mods.json updated with derived metadata.")
+
+    scope = {k: mods[k] for k in args.only} if args.only else mods
+    warnings = collect_warnings(scope)
+    if warnings:
+        with open("pr_body.md", "a", encoding="utf-8") as f:
+            f.write("\n### ⚠️ Curation needed\n\n")
+            for w in warnings:
+                f.write(f"- {w}\n")
+        print(f"⚠️ {len(warnings)} curation warnings appended to pr_body.md")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python3 -m pytest tests/test_derive_mod_metadata.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/derive_mod_metadata.py tests/test_derive_mod_metadata.py
+git commit -m "feat: derive_mod_metadata orchestration with sha256 pinning and curation warnings"
+```
+
+---
+
+### Task 4: `validate_mods.py` — new field checks, empty-games becomes a warning
+
+**Files:**
+- Modify: `scripts/validate_mods.py`
+- Test: `tests/test_validate_mods.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_validate_mods.py`:
+
+```python
+from validate_mods import validate_entry, collect_cross_mod_warnings
+
+
+def _valid():
+    return {
+        "repo": "Lyall/FooFix",
+        "config_files": ["FooFix.ini"],
+        "games": [{"steam_appid": 42, "install_subdir": "Foo/Binaries/Win64"}],
+        "wine_dll_override": "dsound",
+        "loader": "ual",
+        "zip_layout": "flat",
+        "derived_release": "0.0.1",
+        "download_url": "https://codeberg.org/Lyall/FooFix/releases/download/0.0.1/F.zip",
+        "sha256": "0" * 64,
+        "size": 100,
+    }
+
+
+def test_valid_entry_has_no_errors():
+    assert validate_entry("FooFix", _valid()) == []
+
+
+def test_unknown_override_rejected():
+    mod = _valid()
+    mod["wine_dll_override"] = "dxgi"
+    assert any("wine_dll_override" in e for e in validate_entry("FooFix", mod))
+
+
+def test_unsafe_install_subdir_rejected():
+    for bad in ("/abs/path", "a/../../b", ".."):
+        mod = _valid()
+        mod["games"][0]["install_subdir"] = bad
+        assert any("install_subdir" in e for e in validate_entry("FooFix", mod)), bad
+
+
+def test_bad_sha256_rejected_when_derived():
+    mod = _valid()
+    mod["sha256"] = "not-a-hash"
+    assert any("sha256" in e for e in validate_entry("FooFix", mod))
+
+
+def test_offsite_download_url_rejected():
+    mod = _valid()
+    mod["download_url"] = "https://evil.example.com/F.zip"
+    assert any("download_url" in e for e in validate_entry("FooFix", mod))
+
+
+def test_underived_entry_needs_no_pinning_fields():
+    mod = {"repo": "Lyall/New", "config_files": ["New.ini"], "games": [{"steam_appid": 7}]}
+    assert validate_entry("New", mod) == []
+
+
+def test_empty_games_is_warning_not_error():
+    mod = {"repo": "Lyall/New", "config_files": ["New.ini"], "games": []}
+    assert validate_entry("New", mod) == []
+    warnings = collect_cross_mod_warnings({"New": mod})
+    assert any("games" in w for w in warnings)
+
+
+def test_duplicate_appid_warning():
+    mods = {"A": _valid(), "B": _valid()}
+    warnings = collect_cross_mod_warnings(mods)
+    assert any("42" in w for w in warnings)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/test_validate_mods.py -v`
+Expected: FAIL — imports missing.
+
+- [ ] **Step 3: Implement**
+
+Rewrite `scripts/validate_mods.py` — keep `codeberg_get` and the network repo-existence check, restructure validation into pure functions:
+
+```python
+import json
+import os
+import re
+import sys
+import time
+from urllib.parse import urlparse
+
+import requests
+
+from derive_mod_metadata import KNOWN_PROXY_DLLS
+
+API_TOKEN = os.environ.get("CODEBERG_TOKEN")
+CODEBERG_API = "https://codeberg.org/api/v1"
+
+ALLOWED_LOADERS = {"ual", "bepinex", "melonloader"}
+ALLOWED_LAYOUTS = {"flat", "pathed"}
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def codeberg_get(url, retries=3):
+    headers = {}
+    if API_TOKEN:
+        headers["Authorization"] = f"token {API_TOKEN}"
+    for attempt in range(retries):
+        response = requests.get(url, headers=headers, timeout=10)
+        if response.status_code == 200:
+            return response
+        if attempt < retries - 1:
+            time.sleep(2 ** attempt)
+    response.raise_for_status()
+
+
+def _unsafe_subdir(subdir):
+    return subdir.startswith("/") or any(p == ".." for p in subdir.split("/"))
+
+
+def validate_entry(mod_id, mod):
+    """Pure per-entry validation. Returns a list of error strings (empty = valid)."""
+    errors = []
+    if not mod.get("repo"):
+        errors.append("missing repo")
+    if not mod.get("config_files"):
+        errors.append("missing config_files")
+
+    for game in mod.get("games", []):
+        appid = game.get("steam_appid")
+        if not isinstance(appid, int):
+            errors.append(f"invalid steam_appid: {appid!r}")
+        subdir = game.get("install_subdir")
+        if subdir is not None and _unsafe_subdir(subdir):
+            errors.append(f"unsafe install_subdir: {subdir!r}")
+
+    override = mod.get("wine_dll_override")
+    if override is not None and override not in KNOWN_PROXY_DLLS:
+        errors.append(f"unknown wine_dll_override: {override!r}")
+    if mod.get("loader") is not None and mod["loader"] not in ALLOWED_LOADERS:
+        errors.append(f"unknown loader: {mod['loader']!r}")
+    if mod.get("zip_layout") is not None and mod["zip_layout"] not in ALLOWED_LAYOUTS:
+        errors.append(f"unknown zip_layout: {mod['zip_layout']!r}")
+
+    if mod.get("derived_release"):
+        if not SHA256_RE.match(str(mod.get("sha256", ""))):
+            errors.append("bad or missing sha256 for derived entry")
+        url = urlparse(str(mod.get("download_url", "")))
+        if url.scheme != "https" or url.hostname != "codeberg.org":
+            errors.append(f"bad download_url: {mod.get('download_url')!r}")
+        if not isinstance(mod.get("size"), int) or mod["size"] <= 0:
+            errors.append("bad or missing size for derived entry")
+    return errors
+
+
+def collect_cross_mod_warnings(mods):
+    warnings = []
+    seen_appids = {}
+    for mod_id, mod in mods.items():
+        if not mod.get("games"):
+            warnings.append(f"{mod_id}: empty games[] — mod matches no installed game")
+        for game in mod.get("games", []):
+            appid = game.get("steam_appid")
+            if appid in seen_appids and seen_appids[appid] != mod_id:
+                warnings.append(f"appid {appid} claimed by both {seen_appids[appid]} and {mod_id}")
+            seen_appids.setdefault(appid, mod_id)
+    return warnings
+
+
+def validate_mods():
+    if not os.path.exists("mods.json"):
+        print("❌ mods.json not found.")
+        sys.exit(1)
+    try:
+        with open("mods.json", "r", encoding="utf-8") as f:
+            mods = json.load(f)
+    except Exception as e:
+        print(f"❌ Failed to parse mods.json: {e}")
+        sys.exit(1)
+
+    failed = False
+    for mod_id, mod in mods.items():
+        print(f"🔎 Checking mod: {mod_id}")
+        errors = validate_entry(mod_id, mod)
+        for error in errors:
+            print(f"❌ {mod_id}: {error}")
+            failed = True
+        if mod.get("repo"):
+            response = codeberg_get(f"{CODEBERG_API}/repos/{mod['repo']}")
+            if response.status_code != 200:
+                print(f"❌ {mod_id}: Codeberg repo '{mod['repo']}' does not exist.")
+                failed = True
+
+    for warning in collect_cross_mod_warnings(mods):
+        print(f"⚠️ {warning}")
+
+    if failed:
+        sys.exit(1)
+    print("✅ All checks passed for mods.json!")
+
+
+if __name__ == "__main__":
+    validate_mods()
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python3 -m pytest tests/test_validate_mods.py -v`
+Expected: all PASS. Also run the full suite: `python3 -m pytest -q` — all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/validate_mods.py tests/test_validate_mods.py
+git commit -m "feat: validate catalog v2 fields; empty games[] becomes a warning"
+```
+
+---
+
+### Task 5: Wire derivation into CI + add tests workflow
+
+**Files:**
+- Modify: `.github/workflows/refresh-mods.yml`
+- Create: `.github/workflows/tests.yml`
+
+- [ ] **Step 1: Add derive step to refresh-mods.yml**
+
+Insert between the `Update mods.json` step and the `Create Pull Request` step:
+
+```yaml
+      - name: Derive mod metadata
+        run: python scripts/derive_mod_metadata.py
+```
+
+(The `Create Pull Request` step's `add-paths: mods.json` already covers the derived changes; `pr_body.md` is consumed via `body-path`, not committed.)
+
+- [ ] **Step 2: Create `.github/workflows/tests.yml`**
+
+```yaml
+name: Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - 'tests/**'
+      - 'conftest.py'
+  push:
+    branches: [master]
+    paths:
+      - 'scripts/**'
+      - 'tests/**'
+      - 'conftest.py'
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pytest requests
+      - run: python -m pytest -v
+```
+
+- [ ] **Step 3: Validate YAML locally**
+
+Run: `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]" && echo OK`
+(If PyYAML is missing: `pip install pyyaml` first.)
+Expected: `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/refresh-mods.yml .github/workflows/tests.yml
+git commit -m "ci: run metadata derivation in refresh workflow; add pytest workflow"
+```
+
+---
+
+### Task 6: Catalog data fixes + `install_subdir` seeds
+
+**Files:**
+- Modify: `mods.json`
+
+- [ ] **Step 1: Verify the OctopathFix appid correction**
+
+Run: `curl -s "https://store.steampowered.com/api/storesearch/?term=octopath%20traveler&l=english&cc=US" | python3 -m json.tool | head -40`
+Expected: OCTOPATH TRAVELER with id `921570` (Octopath II is 1971650, currently duplicated in the catalog).
+
+- [ ] **Step 2: Verify each seed subdir against its README**
+
+For each mod below, confirm the documented extraction path (the part after the install-root folder):
+
+Run (example for ClairObscurFix): `curl -s "https://codeberg.org/Lyall/ClairObscurFix/raw/branch/main/README.md" | grep -iA2 "installation"`
+Expected: mentions `Expedition 33\Sandfall\Binaries\Win64` → subdir `Sandfall/Binaries/Win64`. Repeat for each seed; adjust any that differ.
+
+- [ ] **Step 3: Apply the edits with a one-off script**
+
+Run from repo root:
+
+```python
+python3 - <<'EOF'
+import json
+
+SEEDS = {
+    "ClairObscurFix": {"*": "Sandfall/Binaries/Win64"},
+    "SMTVFix": {"*": "Project/Binaries/Win64"},
+    "Octopath2Fix": {"*": "Octopath_Traveler2/Binaries/Win64"},
+    "DQXISFix": {"*": "Game/Binaries/Win64"},
+    "MGSDeltaFix": {"*": "MGSDelta/Binaries/Win64"},
+    "SHfFix": {"*": "SHf/Binaries/Win64"},
+    "CrossWorldsFix": {"*": "UNION/Binaries/Win64"},
+    "DQ7RFix": {"*": "DQ7R/Binaries/Win64"},
+    "LEGOBatmanLotDKFix": {"*": "LEGOBatmanLotDK/Binaries/Win64"},
+    "AbsolumFix": {"*": "x64.steam"},
+    "DragonTweak": {2072450: "runtime/media"},  # Infinite Wealth; other appids need curation
+}
+
+with open("mods.json", encoding="utf-8") as f:
+    mods = json.load(f)
+
+# Data fix: OctopathFix has Octopath II's appid (1971650), duplicating Octopath2Fix.
+mods["OctopathFix"]["games"] = [{"steam_appid": 921570}]
+
+for mod_id, seed in SEEDS.items():
+    for game in mods[mod_id]["games"]:
+        sub = seed.get(game["steam_appid"], seed.get("*"))
+        if sub:
+            game["install_subdir"] = sub
+
+with open("mods.json", "w", encoding="utf-8") as f:
+    json.dump(mods, f, indent=2, ensure_ascii=False)
+print("done")
+EOF
+```
+
+- [ ] **Step 4: Validate**
+
+Run: `python3 scripts/validate_mods.py`
+Expected: exits 0; warnings printed for empty-games mods (`DOAXVVPrismFix`, `NoSleepForKanameDateFix` — their appids need manual research, out of scope here) but no ❌ errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mods.json
+git commit -m "fix: correct OctopathFix appid; seed install_subdir for flat-zip mods"
+```
+
+---
+
+### Task 7: Local smoke run of derivation
+
+- [ ] **Step 1: Derive three representative mods** (flat UAL, pathed UAL, BepInEx)
+
+Run: `python3 scripts/derive_mod_metadata.py --only ClairObscurFix FF7RebirthFix RaidouFix`
+Expected: three `🔬 Deriving...` lines; `mods.json updated`.
+
+- [ ] **Step 2: Inspect the derived fields**
+
+Run: `python3 -c "import json; m=json.load(open('mods.json')); print({k: {f: m[k].get(f) for f in ('wine_dll_override','loader','zip_layout','derived_release','sha256','size')} for k in ('ClairObscurFix','FF7RebirthFix','RaidouFix')})"`
+Expected: ClairObscurFix → dsound/ual/flat; FF7RebirthFix → dsound/ual/pathed; RaidouFix → winhttp/bepinex/pathed. (These match the research table; if a value differs, trust the zip and update the research note.)
+
+- [ ] **Step 3: Idempotency check** — re-run the same command.
+
+Run: `python3 scripts/derive_mod_metadata.py --only ClairObscurFix FF7RebirthFix RaidouFix`
+Expected: three `✅ ... up to date` lines, no download, no mods.json change (`git diff --stat mods.json` empty).
+
+- [ ] **Step 4: Full suite + validation**
+
+Run: `python3 -m pytest -q && python3 scripts/validate_mods.py`
+Expected: tests PASS; validation exits 0.
+
+- [ ] **Step 5: Commit and finish**
+
+```bash
+git add mods.json
+git commit -m "chore: derive metadata for smoke-test mods"
+```
+
+Then use superpowers:finishing-a-development-branch (push `feat/catalog-v2`, open a PR to master; the first scheduled refresh run after merge backfills all ~100 mods).

--- a/docs/superpowers/specs/2026-07-06-decky-quickfix-plugin-design.md
+++ b/docs/superpowers/specs/2026-07-06-decky-quickfix-plugin-design.md
@@ -1,0 +1,148 @@
+# QuickFix Decky Plugin — Design
+
+**Date:** 2026-07-06
+**Status:** Approved (pending spec review)
+
+## Overview
+
+Bring QuickFix's job — installing, updating, and removing Lyall's PC game fixes — to SteamOS Gaming Mode via a Decky Loader plugin. The plugin reuses quickfix's `mods.json` catalog (extended with new auto-derived fields) and delegates the Proton-required `WINEDLLOVERRIDES` launch options to the "Launch Options" Decky plugin (Wurielle/decky-launch-options, "DLO") through its documented integration event.
+
+Background: Lyall's fixes are ASI/BepInEx/MelonLoader payloads activated by a proxy DLL (`dsound.dll`, `winmm.dll`, `dinput8.dll`, `version.dll`, or `winhttp.dll`) dropped next to the game executable. Under Proton, Wine's builtin DLL wins by default, so every fix additionally requires the launch option `WINEDLLOVERRIDES="<dll>=n,b" %command%` or it silently never loads. Installing files AND registering that override are therefore both mandatory.
+
+## Goals
+
+- Install/update/uninstall Lyall fixes for installed Steam games from the Quick Access Menu.
+- Register the correct `WINEDLLOVERRIDES` toggle with DLO after each install.
+- Extend `mods.json` so the required metadata (proxy DLL, loader type, extraction subdirectory) is derived automatically by the existing refresh workflow.
+
+## Non-goals (v1)
+
+- INI config viewing/editing in Gaming Mode.
+- Per-game library-page UI integration (route patching).
+- Background/automatic update checks.
+- Fixing the Windows CLI's extraction bug (the new catalog fields enable that as a follow-up).
+- Decky store submission (off-store distribution via "Install from URL").
+
+---
+
+## Part 1 — Catalog v2 (changes in `sharkusmanch/quickfix`)
+
+### Schema additions to `mods.json`
+
+Per-mod (top level, alongside `repo` / `config_files` / `games` / `last_updated`):
+
+| Field | Type | Meaning |
+|---|---|---|
+| `wine_dll_override` | string | Proxy DLL stem, e.g. `"dsound"`. The launch option is `WINEDLLOVERRIDES="<value>=n,b" %command%`. |
+| `loader` | string | `"ual"` \| `"bepinex"` \| `"melonloader"`. Drives UX hints (BepInEx first boot is slow). |
+| `derived_release` | string | Release tag the two fields above were derived from (idempotency marker). |
+
+Per-game (inside each `games[]` entry, optional):
+
+| Field | Type | Meaning |
+|---|---|---|
+| `install_subdir` | string | Path relative to the game install root where the zip contents must land (e.g. `"Sandfall/Binaries/Win64"` for ClairObscurFix). Omitted when extraction to the install root is correct. Per-game because DragonTweak's 8 appids each need a different subdir. |
+
+### Derivation script
+
+New `scripts/derive_mod_metadata.py`, run by the existing `refresh-mods.yml` workflow after `update_mods.py`:
+
+1. For each mod whose latest release tag differs from `derived_release` (or whose fields are missing): download the latest release zip from Codeberg, list entries with `\` normalized to `/`.
+2. `wine_dll_override` = basename stem of the bundled DLL whose name is in the known proxy set (`dsound`, `winmm`, `dinput8`, `version`, `winhttp`, plus the remaining Ultimate ASI Loader x64 names). The zip is the source of truth, not the README — the one known README/zip mismatch (GreatCircleFix) is resolved in the zip's favor. `dxgi` is never auto-selected (would conflict with DXVK); if only unexpected DLLs are found, leave the field unset and flag it.
+3. `loader`: `BepInEx/` entry → `bepinex`; `MelonLoader/` entry → `melonloader`; any `.asi` → `ual`.
+4. Flat-zip detection: if the zip has no directory structure and the mod has games without `install_subdir`, add a warning line to `pr_body.md` so it gets curated manually in the auto-refresh PR.
+5. Write `derived_release`.
+
+`install_subdir` itself is manually curated (never overwritten by the script). Seed values from research: ClairObscurFix `Sandfall/Binaries/Win64`, SMTVFix `Project/Binaries/Win64`, Octopath2Fix `Octopath_Traveler2/Binaries/Win64`, DQXISFix `Game/Binaries/Win64`, MGSDeltaFix `MGSDelta/Binaries/Win64`, SHfFix `SHf/Binaries/Win64`, CrossWorldsFix `UNION/Binaries/Win64`, DQ7RFix `DQ7R/Binaries/Win64`, LEGOBatmanLotDKFix `LEGOBatmanLotDK/Binaries/Win64`, AbsolumFix `x64.steam`, DragonTweak per-appid (e.g. `runtime/media` for Infinite Wealth). Note: these are relative to the game install root, whose top-level folder name is already known from the appmanifest, so stored subdirs must exclude the install root component; exact values verified during implementation.
+
+`scripts/validate_mods.py` gains checks: `wine_dll_override` (when present) is in the known proxy set; `loader` in the allowed enum; `install_subdir` contains no `..` or leading `/`.
+
+Windows `quickfix.py` ignores the new fields for now (unknown keys are already tolerated).
+
+---
+
+## Part 2 — New repo `decky-quickfix` (plugin name: "QuickFix")
+
+Based on `SteamDeckHomebrew/decky-plugin-template`: `api_version: 1`, `@decky/ui` + `@decky/api`, rollup via `@decky/rollup`, pnpm 9. **No `root` flag** — the `deck` user owns all Steam library paths, including SD cards. No compiled backend.
+
+### Python backend (`main.py`, helpers in `py_modules/`)
+
+Runs on Decky's frozen Python 3.11 (aiohttp + certifi available; no pip, no requests).
+
+**Catalog:** fetch `https://raw.githubusercontent.com/sharkusmanch/quickfix/master/mods.json` on load and on manual refresh; cache in `DECKY_PLUGIN_SETTINGS_DIR/mods.json` for offline use. Skip mods lacking `wine_dll_override` (not yet derivable).
+
+**Game detection** (port of quickfix.py minus winreg): probe Steam roots `~/.local/share/Steam`, `~/.steam/steam`, `~/.steam/root`; parse `steamapps/libraryfolders.vdf` for library paths (this covers SD card/USB libraries — never hardcode `/run/media`); parse `appmanifest_<appid>.acf` for `installdir` → `<library>/steamapps/common/<installdir>`. Regex line-parsing as today; no vendored `vdf` package needed.
+
+**Download:** Codeberg API `GET /repos/{repo}/releases/latest`, pick the `.zip` asset; download via aiohttp with `ssl.create_default_context(cafile=certifi.where())` into `DECKY_PLUGIN_RUNTIME_DIR/downloads/`.
+
+**Extractor (hardened, new):**
+- Normalize `\` → `/` in every zip entry name (SyberiaTWBFix's current release uses backslash separators, which stock `zipfile.extractall` turns into junk files on Linux).
+- Zip-slip guard: reject entries resolving outside the target directory.
+- Skip the `EXTRACT_TO_GAME_FOLDER` marker file.
+- Target directory: `install_path + install_subdir` when the game entry has one; otherwise, if the zip is flat (no directories) and the install root lacks the game's shipping exe, locate `**/Binaries/Win64/*-Shipping.exe` (Unreal heuristic) and extract there; else extract to the install root.
+- Merge into existing directories case-insensitively (ext4 is case-sensitive; a case-mismatched duplicate tree means the DLL never loads).
+- Before overwriting an existing file, copy it to `DECKY_PLUGIN_RUNTIME_DIR/backups/<appid>-<mod_id>/`.
+
+**Install manifest:** `DECKY_PLUGIN_RUNTIME_DIR/installs/<appid>-<mod_id>.json` with `{mod_id, appid, version, install_path, target_dir, files[], backed_up_files[], wine_dll_override, installed_at}`. Status is re-derived from disk (manifest + files present), so it survives reinstall/reboot. Uninstall deletes listed files, restores backups, removes the manifest.
+
+**Safety:** refuse install/uninstall while the game is running (scan `/proc` cmdlines for the install path).
+
+**Callables** (all `async` methods on `Plugin`):
+- `get_state()` → `{catalog_loaded, games: [{appid, mod_id, install_path, installed_version, latest_version, wine_dll_override, loader, status}]}` where `status` ∈ `not_installed | installed | update_available | unknown`. Only games present both on disk and in the catalog.
+- `refresh()` → re-fetch catalog and latest release versions.
+- `install(mod_id, appid)` / `uninstall(mod_id, appid)` → `{ok, error?, wine_dll_override?}`.
+- Progress: `decky.emit("qf_progress", mod_id, appid, phase, pct)` for download/extract phases.
+
+Version checks call Codeberg per mod; do them lazily (on QAM open / explicit refresh), not on a timer.
+
+### Frontend (`src/`)
+
+- `index.tsx`: `definePlugin`; on mount, detect `(window as any).hasDeckyLaunchOptions`.
+- **QAM panel:** list of detected games with available fixes — display name via `appStore.GetAppOverviewByAppID(appid)` (retry-wrapped), status line (`Installed 0.0.15 · 0.0.16 available`), context-aware button (Install / Update / Uninstall), refresh button, `toaster.toast` on completion/failure, progress from `qf_progress` events. For BepInEx mods, the post-install toast warns that first boot takes minutes.
+- **DLO required:** if `hasDeckyLaunchOptions` is falsy, the panel shows an explanation ("QuickFix needs the 'Launch Options' plugin from the Decky store to activate fixes under Proton") and install buttons are disabled. No direct `SetAppLaunchOptions` writes in v1.
+- **DLO registration:** after a successful install, dispatch:
+  ```ts
+  window.dispatchEvent(new CustomEvent('dlo-add-launch-options', {
+    detail: [{
+      id: `quickfix-${modId}`,          // stable → re-dispatch upserts
+      group: 'QuickFix',
+      name: `${modId} (${dll} override)`,
+      on: `WINEDLLOVERRIDES="${dll}=n,b"`,  // env-only; DLO merges WINEDLLOVERRIDES across options with ';'
+      off: '',
+      enableGlobally: false,
+    }]
+  }));
+  ```
+  DLO shows its confirm dialog; a follow-up toast tells the user to enable the toggle on the game's page. Uninstall cannot remove DLO options (no such event exists); the toast tells the user to disable the toggle. Upstream feature request to file with Wurielle: a per-app enable/remove event.
+
+### Error handling
+
+- Network failures: fall back to cached catalog; per-mod version check failures degrade that row to `unknown` with a retry affordance.
+- Extraction failure mid-way: restore backups and delete files written so far (track as we go), report via toast + `decky.logger`.
+- All backend exceptions bubble to the frontend as JS errors — every callable invocation is try/caught in the API layer and surfaced as a toast.
+
+### Repo layout, CI, distribution
+
+- Template-derived layout: `main.py`, `py_modules/quickfix_core/` (detection, download, extract, manifest — unit-testable pure Python), `src/`, `plugin.json` (`flags: []`), `package.json`, `defaults/`.
+- GitHub Actions: lint + pytest for `py_modules/quickfix_core` (fixture zips: flat, pathed, backslash-entries, zip-slip), `pnpm build`, decky CLI zip build; on tag push, attach the zip to a GitHub release.
+- Install URL for users: `https://github.com/sharkusmanch/decky-quickfix/releases/latest/download/quickfix.zip` via Decky Settings → Developer → Install from URL.
+- Dev loop: rsync to `deck@<ip>:~/homebrew/plugins` + `systemctl restart plugin_loader`; CEF debugging via `chrome://inspect` → `<deck-ip>:8081`.
+
+### Testing
+
+- Unit tests (CI, no Deck): extractor rules against fixture zips; manifest/uninstall round-trip in a temp dir; vdf/acf parsing against captured Deck fixtures.
+- On-device smoke test (manual): one mod per shape — ClairObscurFix (flat + subdir + dsound), FF7RebirthFix (pathed + dsound), a winmm mod (e.g. MGSVFix), a BepInEx mod (e.g. RaidouFix) — verifying files land next to the shipping exe, DLO import appears, and the fix loads in-game with the toggle on.
+
+## Risks / notes
+
+- `SteamClient`/`appStore` internals are unversioned Valve APIs; the blast radius is limited to display names (worst case: show appids).
+- DLO's store version lags GitHub; the integration event exists since v1.8 but field-level compatibility (e.g. `priority`) should be tested against the store build.
+- Steam game updates can break offset-based fixes until Lyall updates them — the update flow covers recovery, and this is upstream of us.
+- Games on NTFS external drives are a general Proton problem, unrelated to the plugin.
+
+## Follow-ups (explicitly out of v1)
+
+1. Use `install_subdir` in Windows `quickfix.py` (fixes the current Layout-B bug where the proxy DLL lands next to the launcher stub).
+2. Upstream DLO feature request: programmatic per-app option enable/remove.
+3. Optional `quickfix-recipes.json` for DLO's Recipes companion plugin as a code-free alternative channel.
+4. INI config editor, per-game page integration, background update checks.

--- a/docs/superpowers/specs/2026-07-06-decky-quickfix-plugin-design.md
+++ b/docs/superpowers/specs/2026-07-06-decky-quickfix-plugin-design.md
@@ -61,7 +61,7 @@ Windows `quickfix.py` ignores the new fields for now (unknown keys are already t
 
 ---
 
-## Part 2 — New repo `decky-quickfix` (plugin name: "QuickFix")
+## Part 2 — Plugin repo `decky-lyall` (display name: "Lyall Fixes")
 
 Based on `SteamDeckHomebrew/decky-plugin-template`: `api_version: 1`, `@decky/ui` + `@decky/api`, rollup via `@decky/rollup`, pnpm 9. **No `root` flag** — the `deck` user owns all Steam library paths, including SD cards. No compiled backend.
 
@@ -99,13 +99,13 @@ Version checks call Codeberg per mod; do them lazily (on QAM open / explicit ref
 
 - `index.tsx`: `definePlugin`; on mount, detect `(window as any).hasDeckyLaunchOptions`.
 - **QAM panel:** list of detected games with available fixes — display name via `appStore.GetAppOverviewByAppID(appid)` (retry-wrapped), status line (`Installed 0.0.15 · 0.0.16 available`), context-aware button (Install / Update / Uninstall), refresh button, `toaster.toast` on completion/failure, progress from `qf_progress` events. For BepInEx mods, the post-install toast warns that first boot takes minutes.
-- **DLO required:** if `hasDeckyLaunchOptions` is falsy, the panel shows an explanation ("QuickFix needs the 'Launch Options' plugin from the Decky store to activate fixes under Proton") and install buttons are disabled. No direct `SetAppLaunchOptions` writes in v1.
+- **DLO required:** if `hasDeckyLaunchOptions` is falsy, the panel shows an explanation ("Lyall Fixes needs the 'Launch Options' plugin from the Decky store to activate fixes under Proton") and install buttons are disabled. No direct `SetAppLaunchOptions` writes in v1.
 - **DLO registration:** after a successful install, dispatch:
   ```ts
   window.dispatchEvent(new CustomEvent('dlo-add-launch-options', {
     detail: [{
-      id: `quickfix-${modId}`,          // stable → re-dispatch upserts
-      group: 'QuickFix',
+      id: `lyall-${modId}`,             // stable → re-dispatch upserts
+      group: 'Lyall Fixes',
       name: `${modId} (${dll} override)`,
       on: `WINEDLLOVERRIDES="${dll}=n,b"`,  // env-only; DLO merges WINEDLLOVERRIDES across options with ';'
       off: '',
@@ -123,9 +123,9 @@ Version checks call Codeberg per mod; do them lazily (on QAM open / explicit ref
 
 ### Repo layout, CI, distribution
 
-- Template-derived layout: `main.py`, `py_modules/quickfix_core/` (detection, download, extract, manifest — unit-testable pure Python), `src/`, `plugin.json` (`flags: []`), `package.json`, `defaults/`.
-- GitHub Actions: lint + pytest for `py_modules/quickfix_core` (fixture zips: flat, pathed, backslash-entries, zip-slip), `pnpm build`, decky CLI zip build; on tag push, attach the zip to a GitHub release.
-- Install URL for users: `https://github.com/sharkusmanch/decky-quickfix/releases/latest/download/quickfix.zip` via Decky Settings → Developer → Install from URL.
+- Template-derived layout: `main.py`, `py_modules/lyall_core/` (detection, download, extract, manifest — unit-testable pure Python), `src/`, `plugin.json` (`flags: []`), `package.json`, `defaults/`.
+- GitHub Actions: lint + pytest for `py_modules/lyall_core` (fixture zips: flat, pathed, backslash-entries, zip-slip), `pnpm build`, decky CLI zip build; on tag push, attach the zip to a GitHub release.
+- Install URL for users: `https://github.com/sharkusmanch/decky-lyall/releases/latest/download/decky-lyall.zip` via Decky Settings → Developer → Install from URL.
 - Dev loop: rsync to `deck@<ip>:~/homebrew/plugins` + `systemctl restart plugin_loader`; CEF debugging via `chrome://inspect` → `<deck-ip>:8081`.
 
 ### Testing

--- a/docs/superpowers/specs/2026-07-06-decky-quickfix-plugin-design.md
+++ b/docs/superpowers/specs/2026-07-06-decky-quickfix-plugin-design.md
@@ -1,7 +1,7 @@
 # QuickFix Decky Plugin — Design
 
-**Date:** 2026-07-06
-**Status:** Approved (pending spec review)
+**Date:** 2026-07-06 (rev 2, after multi-agent review)
+**Status:** Approved design; rev 2 amendments pending user review
 
 ## Overview
 
@@ -12,14 +12,15 @@ Background: Lyall's fixes are ASI/BepInEx/MelonLoader payloads activated by a pr
 ## Goals
 
 - Install/update/uninstall Lyall fixes for installed Steam games from the Quick Access Menu.
-- Register the correct `WINEDLLOVERRIDES` toggle with DLO after each install.
-- Extend `mods.json` so the required metadata (proxy DLL, loader type, extraction subdirectory) is derived automatically by the existing refresh workflow.
+- Register the correct `WINEDLLOVERRIDES` toggle with DLO after each install, with visible activation state.
+- Extend `mods.json` so the required metadata (proxy DLL, loader type, extraction layout, pinned asset hash) is derived automatically by the existing refresh workflow.
 
 ## Non-goals (v1)
 
 - INI config viewing/editing in Gaming Mode.
 - Per-game library-page UI integration (route patching).
 - Background/automatic update checks.
+- Programmatic launch-option writes (`SteamClient.Apps.SetAppLaunchOptions`) — DLO or manual copy only.
 - Fixing the Windows CLI's extraction bug (the new catalog fields enable that as a follow-up).
 - Decky store submission (off-store distribution via "Install from URL").
 
@@ -35,29 +36,42 @@ Per-mod (top level, alongside `repo` / `config_files` / `games` / `last_updated`
 |---|---|---|
 | `wine_dll_override` | string | Proxy DLL stem, e.g. `"dsound"`. The launch option is `WINEDLLOVERRIDES="<value>=n,b" %command%`. |
 | `loader` | string | `"ual"` \| `"bepinex"` \| `"melonloader"`. Drives UX hints (BepInEx first boot is slow). |
-| `derived_release` | string | Release tag the two fields above were derived from (idempotency marker). |
+| `zip_layout` | string | `"pathed"` (zip embeds relative paths from install root) \| `"flat"` (payload files at zip root). Determines extraction target selection. |
+| `derived_release` | string | Release tag the derived fields were computed from. **Doubles as the plugin's `latest_version` source** — the plugin makes zero Codeberg API calls for version checks. |
+| `download_url` | string | Exact `browser_download_url` of the .zip asset the derivation script inspected. |
+| `sha256` | string | Lowercase hex SHA-256 of that asset. Installs verify against this before extraction. |
+| `size` | int | Asset byte size (cheap pre-check + download-progress denominator). |
+
+Pinning rationale (review finding, critical): Forgejo release assets are mutable without a tag change, so installing unpinned "latest" assets would let a compromised upstream account deliver arbitrary code, and `derived_release` idempotency would never re-inspect a swapped asset. Pinning also eliminates metadata/payload version skew by construction: the plugin installs exactly the zip the derivation script inspected. Precedent: Decky-Framegen and decky-16x10-fixes both pin sha256.
 
 Per-game (inside each `games[]` entry, optional):
 
 | Field | Type | Meaning |
 |---|---|---|
-| `install_subdir` | string | Path relative to the game install root where the zip contents must land (e.g. `"Sandfall/Binaries/Win64"` for ClairObscurFix). Omitted when extraction to the install root is correct. Per-game because DragonTweak's 8 appids each need a different subdir. |
+| `install_subdir` | string | Path relative to the game install root where a **flat** zip's contents must land (e.g. `"Sandfall/Binaries/Win64"` for ClairObscurFix). Required for flat-layout mods; per-game because DragonTweak's 8 appids each need a different subdir. |
+
+Constraint: `mods.json` is a flat dict whose every top-level key the Windows CLI treats as a mod (`list-mods` iterates `mods.keys()`), so **no top-level metadata/version key can be added** until the CLI is updated. Schema versioning lives in the plugin's install manifests instead.
 
 ### Derivation script
 
 New `scripts/derive_mod_metadata.py`, run by the existing `refresh-mods.yml` workflow after `update_mods.py`:
 
-1. For each mod whose latest release tag differs from `derived_release` (or whose fields are missing): download the latest release zip from Codeberg, list entries with `\` normalized to `/`.
+1. For each mod whose latest release tag differs from `derived_release` (or whose derived fields are missing): download the latest release zip from Codeberg, list entries with `\` normalized to `/`.
 2. `wine_dll_override` = basename stem of the bundled DLL whose name is in the known proxy set (`dsound`, `winmm`, `dinput8`, `version`, `winhttp`, plus the remaining Ultimate ASI Loader x64 names). The zip is the source of truth, not the README — the one known README/zip mismatch (GreatCircleFix) is resolved in the zip's favor. `dxgi` is never auto-selected (would conflict with DXVK); if only unexpected DLLs are found, leave the field unset and flag it.
 3. `loader`: `BepInEx/` entry → `bepinex`; `MelonLoader/` entry → `melonloader`; any `.asi` → `ual`.
-4. Flat-zip detection: if the zip has no directory structure and the mod has games without `install_subdir`, add a warning line to `pr_body.md` so it gets curated manually in the auto-refresh PR.
-5. Write `derived_release`.
+4. `zip_layout`: `pathed` if payload entries carry directory paths from the install root; `flat` otherwise.
+5. Record `download_url`, `sha256` (of the downloaded bytes), `size`, and `derived_release`. `derived_release` is written on every run for every mod with a resolvable release, including mods whose other fields were flagged rather than derived.
+6. Append warnings to `pr_body.md` for human curation in the auto-refresh PR: flat-layout mods with any game entry missing `install_subdir`; mods where `wine_dll_override` could not be derived; mods with empty `games[]`; appids claimed by more than one mod.
 
-`install_subdir` itself is manually curated (never overwritten by the script). Seed values from research: ClairObscurFix `Sandfall/Binaries/Win64`, SMTVFix `Project/Binaries/Win64`, Octopath2Fix `Octopath_Traveler2/Binaries/Win64`, DQXISFix `Game/Binaries/Win64`, MGSDeltaFix `MGSDelta/Binaries/Win64`, SHfFix `SHf/Binaries/Win64`, CrossWorldsFix `UNION/Binaries/Win64`, DQ7RFix `DQ7R/Binaries/Win64`, LEGOBatmanLotDKFix `LEGOBatmanLotDK/Binaries/Win64`, AbsolumFix `x64.steam`, DragonTweak per-appid (e.g. `runtime/media` for Infinite Wealth). Note: these are relative to the game install root, whose top-level folder name is already known from the appmanifest, so stored subdirs must exclude the install root component; exact values verified during implementation.
+**Prerequisite fix in `scripts/update_mods.py` (review finding, critical):** it currently rebuilds every existing entry with exactly four keys (`repo`, `config_files`, `games`, `last_updated`) and replaces the entry whenever the rebuilt dict differs — which would strip all derived fields on every 6-hour run and silently force `derive_mod_metadata.py` to re-download all ~100 zips forever. Change it to start `new_entry` from a copy of the existing entry and update only the four keys it owns, preserving unknown fields.
 
-`scripts/validate_mods.py` gains checks: `wine_dll_override` (when present) is in the known proxy set; `loader` in the allowed enum; `install_subdir` contains no `..` or leading `/`.
+`install_subdir` is manually curated (never overwritten by the script). Seed values from research: ClairObscurFix `Sandfall/Binaries/Win64`, SMTVFix `Project/Binaries/Win64`, Octopath2Fix `Octopath_Traveler2/Binaries/Win64`, DQXISFix `Game/Binaries/Win64`, MGSDeltaFix `MGSDelta/Binaries/Win64`, SHfFix `SHf/Binaries/Win64`, CrossWorldsFix `UNION/Binaries/Win64`, DQ7RFix `DQ7R/Binaries/Win64`, LEGOBatmanLotDKFix `LEGOBatmanLotDK/Binaries/Win64`, AbsolumFix `x64.steam`, DragonTweak per-appid (e.g. `runtime/media` for Infinite Wealth). Paths are relative to the game install root (exclude the install-root folder itself); exact values verified during implementation.
 
-Windows `quickfix.py` ignores the new fields for now (unknown keys are already tolerated).
+Known catalog data fixes to make alongside: `OctopathFix` currently lists appid 1971650, which belongs to Octopath Traveler II and is also claimed by `Octopath2Fix` (bad auto-guess); correct it to Octopath Traveler 1's appid. `DOAXVVPrismFix` and `NoSleepForKanameDateFix` have empty `games[]`.
+
+`scripts/validate_mods.py` gains checks: `wine_dll_override` (when present) in the known proxy set; `loader` and `zip_layout` in their enums; `install_subdir` contains no `..`, no leading `/`; `sha256` matches `^[0-9a-f]{64}$`; `download_url` is https on codeberg.org; `size` positive int; all pinning fields present whenever `derived_release` is set; warn on appids claimed by multiple mods and on empty `games[]`.
+
+Windows `quickfix.py` ignores the new fields for now (unknown keys are tolerated at read time; the update_mods.py fix above makes them survive refresh).
 
 ---
 
@@ -65,42 +79,48 @@ Windows `quickfix.py` ignores the new fields for now (unknown keys are already t
 
 Based on `SteamDeckHomebrew/decky-plugin-template`: `api_version: 1`, `@decky/ui` + `@decky/api`, rollup via `@decky/rollup`, pnpm 9. **No `root` flag** — the `deck` user owns all Steam library paths, including SD cards. No compiled backend.
 
-### Python backend (`main.py`, helpers in `py_modules/`)
+### Python backend (`main.py`, helpers in `py_modules/lyall_core/`)
 
 Runs on Decky's frozen Python 3.11 (aiohttp + certifi available; no pip, no requests).
 
-**Catalog:** fetch `https://raw.githubusercontent.com/sharkusmanch/quickfix/master/mods.json` on load and on manual refresh; cache in `DECKY_PLUGIN_SETTINGS_DIR/mods.json` for offline use. Skip mods lacking `wine_dll_override` (not yet derivable).
+**Catalog:** fetch `https://raw.githubusercontent.com/sharkusmanch/quickfix/master/mods.json` on load and on `refresh()`; cache in `DECKY_PLUGIN_SETTINGS_DIR/mods.json` (with fetch timestamp) for offline use. **Plugin-side validation (defense in depth — the catalog is remote input):** mod ids must match `^[A-Za-z0-9._-]+$` (they become path components); `wine_dll_override` must be in the plugin's own proxy-DLL allowlist (it is interpolated into the DLO `on` string, which DLO shlex-parses and executes); `install_subdir` must be relative with no `..` segments; `download_url` must be https on codeberg.org; appids must be ints. Entries failing validation, or lacking `wine_dll_override`/`sha256`/`download_url`, are skipped.
 
 **Game detection** (port of quickfix.py minus winreg): probe Steam roots `~/.local/share/Steam`, `~/.steam/steam`, `~/.steam/root`; parse `steamapps/libraryfolders.vdf` for library paths (this covers SD card/USB libraries — never hardcode `/run/media`); parse `appmanifest_<appid>.acf` for `installdir` → `<library>/steamapps/common/<installdir>`. Regex line-parsing as today; no vendored `vdf` package needed.
 
-**Download:** Codeberg API `GET /repos/{repo}/releases/latest`, pick the `.zip` asset; download via aiohttp with `ssl.create_default_context(cafile=certifi.where())` into `DECKY_PLUGIN_RUNTIME_DIR/downloads/`.
+**Download:** always the catalog-pinned `download_url` (never `releases/latest`), via aiohttp with `ssl.create_default_context(cafile=certifi.where())`, streamed in chunks to `DECKY_PLUGIN_RUNTIME_DIR/downloads/<mod_id>-<tag>.zip` — the local filename is generated locally (mod_id from our validated catalog; tag validated against `^[A-Za-z0-9._-]+$`); the remote asset name is never used as a path component. SHA-256 is computed as bytes arrive; abort if the byte count exceeds the catalog `size`. Before extraction, the hash must equal the catalog `sha256`; on mismatch, delete the file and fail with a distinct error ("asset failed verification — upstream changed or catalog is stale; try Refresh"). The verified sha256 is recorded in the install manifest.
+
+**Version checks:** zero runtime Codeberg API calls. `latest_version` = the catalog's `derived_release`; `installed_version` comes from the install manifest. `refresh()` just re-fetches `mods.json` (update visibility lags the 6-hour workflow cadence at most). The QAM panel shows "Catalog updated: X ago" from the cached catalog's fetch timestamp.
 
 **Extractor (hardened, new):**
 - Normalize `\` → `/` in every zip entry name (SyberiaTWBFix's current release uses backslash separators, which stock `zipfile.extractall` turns into junk files on Linux).
-- Zip-slip guard: reject entries resolving outside the target directory.
+- Zip-slip guard (applied after normalization, per entry): reject entries whose name is absolute, matches a drive-letter prefix (`^[A-Za-z]:`), or contains any `..` segment. Never create symlinks: skip entries whose `external_attr` upper bits mark `S_IFLNK`. Enforce containment on the **final** destination — after the case-insensitive remap — via `os.path.realpath(dest)` inside `os.path.realpath(target_dir)` (compare with trailing separator / `os.path.commonpath`); realpath resolution also prevents escape through pre-existing symlinked directories.
+- Resource caps: reject archives declaring >10,000 entries or >4 GB total uncompressed; enforce the same limits on actual bytes written (zip headers can lie). Exceeding a cap aborts and triggers rollback.
 - Skip the `EXTRACT_TO_GAME_FOLDER` marker file.
-- Target directory: `install_path + install_subdir` when the game entry has one; otherwise, if the zip is flat (no directories) and the install root lacks the game's shipping exe, locate `**/Binaries/Win64/*-Shipping.exe` (Unreal heuristic) and extract there; else extract to the install root.
-- Merge into existing directories case-insensitively (ext4 is case-sensitive; a case-mismatched duplicate tree means the DLL never loads).
-- Before overwriting an existing file, copy it to `DECKY_PLUGIN_RUNTIME_DIR/backups/<appid>-<mod_id>/`.
+- **Target directory selection (no heuristics):** `zip_layout: pathed` → extract to the install root. `zip_layout: flat` with `install_subdir` on the game entry → extract to `install_path/install_subdir`. `zip_layout: flat` **without** `install_subdir` → the install is **blocked**: the row renders as `needs_curation` ("awaiting catalog data") and no Install button is shown. Silent wrong-place extraction (which would report "installed" while the fix never loads) is worse than refusing. The derivation warnings in Part 1 are the curation feed. (The earlier Unreal shipping-exe runtime heuristic is dropped: all known flat-layout mods get curated subdirs, and the heuristic couldn't cover the non-UE cases anyway.)
+- Case-insensitive merge, bounded: a thin path-resolution walk that matches each path component against existing entries case-insensitively (prefer exact match, else the existing variant). If a component collides with an existing **file** where a directory is needed, or two existing entries differ only in case, fail the install with `extract_failed` — no general merge engine.
+- Transactional rollback: every file overwritten during an install/update (including the mod's own previous-version files) is first copied to a per-operation staging dir; on failure, staged copies are restored and newly written files deleted; on success the staging dir is discarded.
 
-**Install manifest:** `DECKY_PLUGIN_RUNTIME_DIR/installs/<appid>-<mod_id>.json` with `{mod_id, appid, version, install_path, target_dir, files[], backed_up_files[], wine_dll_override, installed_at}`. Status is re-derived from disk (manifest + files present), so it survives reinstall/reboot. Uninstall deletes listed files, restores backups, removes the manifest.
+**Pristine backups (distinct from rollback staging):** before overwriting a file, copy it to `DECKY_PLUGIN_RUNTIME_DIR/backups/<appid>-<mod_id>/<path relative to install root>` **only if it is pristine** — i.e. not listed in the current manifest's `files[]` for this (appid, mod_id). Backups are write-once; the mod's own files from a previous version are never backed up. (Review finding: the naive "back up before overwrite" rule would clobber pristine game files with mod v1 files on update, making uninstall restore the wrong bytes.)
 
-**Safety:** refuse install/uninstall while the game is running (scan `/proc` cmdlines for the install path).
+**Install manifest:** `DECKY_PLUGIN_RUNTIME_DIR/installs/<appid>-<mod_id>.json` with `{schema: 1, mod_id, appid, version, sha256, install_path, target_dir, files[], backed_up_files[], wine_dll_override, launch_option_handled, installed_at}`. On update: carry `backed_up_files[]` forward unchanged, replace `files[]`/`version`/`sha256`, and delete files from the old `files[]` that the new release no longer ships. Uninstall: delete `files[]`, restore each `backed_up_files[]` entry to its recorded relative path, remove the manifest and backup dir. Status is re-derived from disk. `refresh()` prunes manifests (and backups) whose game install dir no longer exists — Steam removed the whole dir on game uninstall, so restoration is meaningless; a later game reinstall starts clean as `not_installed`.
 
-**Callables** (all `async` methods on `Plugin`):
-- `get_state()` → `{catalog_loaded, games: [{appid, mod_id, install_path, installed_version, latest_version, wine_dll_override, loader, status}]}` where `status` ∈ `not_installed | installed | update_available | unknown`. Only games present both on disk and in the catalog.
-- `refresh()` → re-fetch catalog and latest release versions.
-- `install(mod_id, appid)` / `uninstall(mod_id, appid)` → `{ok, error?, wine_dll_override?}`.
-- Progress: `decky.emit("qf_progress", mod_id, appid, phase, pct)` for download/extract phases.
+**Concurrency & lifecycle (review finding):** one operation per appid at a time — an in-memory operations table `{appid: {op, mod_id, phase, pct}}`; `install()`/`uninstall()` validate, register the operation (returning `{ok: false, code: "already_in_progress"}` if the appid is busy), spawn the work as an asyncio task, and return `{ok: true, accepted: true}` immediately. Completion is delivered via `decky.emit("qf_done", mod_id, appid, ok, code?, wine_dll_override?)` — it must not depend on the frontend still awaiting the call. Progress via `decky.emit("qf_progress", mod_id, appid, phase, pct)` (pct from catalog `size` during download, entry-count during extraction; `null` = indeterminate). The running-game guard (scan `/proc` cmdlines for the install path) runs at operation start, **before** download.
 
-Version checks call Codeberg per mod; do them lazily (on QAM open / explicit refresh), not on a timer.
+**One mod per game:** if a manifest already exists for an appid, other catalog mods matching that appid render with Install disabled ("another fix is installed for this game") — two mods extracting into one game dir (e.g. two dsound proxies) would corrupt each other's state. Duplicate-appid rows themselves remain visible.
+
+**DLO override status (best-effort probe):** read `<DECKY_USER_HOME>/.dlo/settings.json` (DLO's internal state file). Derive per-(mod, appid) `override_status`: `not_registered` if no `launchOptions[]` entry has id `lyall-<modId>`; else `registered_enabled` / `registered_disabled` from `profiles[appid].state`. Missing file, parse error, unexpected shape → `unknown`; the probe must never fail `get_state()`, and `unknown` renders neutrally (no false alarms). This file is DLO-internal, not a contract (verified at v1.12; the store build may differ) — hence best-effort only.
+
+**Callables** (all return a structured envelope — see Error handling):
+- `get_state()` → `{ok, catalog_updated_at, games: [{appid, mod_id, install_path, installed_version, latest_version, wine_dll_override, loader, status, override_status, busy}]}` where `status` ∈ `not_installed | installed | update_available | needs_curation | needs_launch_option | unknown` and `busy` = `{op, phase, pct} | null` from the operations table (so a remounted panel restores in-flight state without waiting for events).
+- `refresh()` → re-fetch catalog, prune orphaned manifests.
+- `install(mod_id, appid)` / `uninstall(mod_id, appid)` → `{ok, accepted}` or `{ok: false, code, message}`.
 
 ### Frontend (`src/`)
 
-- `index.tsx`: `definePlugin`; on mount, detect `(window as any).hasDeckyLaunchOptions`.
-- **QAM panel:** list of detected games with available fixes — display name via `appStore.GetAppOverviewByAppID(appid)` (retry-wrapped), status line (`Installed 0.0.15 · 0.0.16 available`), context-aware button (Install / Update / Uninstall), refresh button, `toaster.toast` on completion/failure, progress from `qf_progress` events. For BepInEx mods, the post-install toast warns that first boot takes minutes.
-- **DLO required:** if `hasDeckyLaunchOptions` is falsy, the panel shows an explanation ("Lyall Fixes needs the 'Launch Options' plugin from the Decky store to activate fixes under Proton") and install buttons are disabled. No direct `SetAppLaunchOptions` writes in v1.
-- **DLO registration:** after a successful install, dispatch:
+- `index.tsx`: `definePlugin`; `qf_progress`/`qf_done` listeners registered at module scope (removed in `onDismount`, not the panel component) so completion toasts and DLO registration fire even when the QAM panel is closed. `hasDeckyLaunchOptions` is read live on every render — never cached at mount (plugin load order is not guaranteed; DLO may load or be installed later).
+- **QAM panel:** rows for detected games with catalog fixes — display name via `appStore.GetAppOverviewByAppID(appid)` (retry-wrapped), status line, context-aware button (Install / Update / Uninstall / disabled states), progress bar for `busy` rows, Refresh button with "Catalog updated: X ago". Rows sort by actionability: busy → update_available → installed-with-warning → installed → not_installed → needs_curation; stable order within groups so rows don't jump under controller focus.
+- **Activation visibility (review finding — this is the plugin's primary failure mode):** an installed fix whose override isn't active loads nothing while the panel would happily say "Installed". When `status` is installed/update_available and `override_status` is `not_registered`/`registered_disabled`, the row shows a persistent warning ("Fix installed — launch override not enabled") plus a **"Register launch option"** button that re-dispatches the DLO event (safe: stable id upserts). This also covers the user declining/missing DLO's confirm dialog, which has no acknowledgment API.
+- **DLO registration:** after a successful install (on `qf_done`), dispatch:
   ```ts
   window.dispatchEvent(new CustomEvent('dlo-add-launch-options', {
     detail: [{
@@ -113,36 +133,40 @@ Version checks call Codeberg per mod; do them lazily (on QAM open / explicit ref
     }]
   }));
   ```
-  DLO shows its confirm dialog; a follow-up toast tells the user to enable the toggle on the game's page. Uninstall cannot remove DLO options (no such event exists); the toast tells the user to disable the toggle. Upstream feature request to file with Wurielle: a per-app enable/remove event.
+  Then a `showModal` ConfirmModal (not a transient toast) gives the activation path **matching DLO's real UI**: DLO's per-game toggles live on DLO's own per-app page, reached via the "Launch Options" item DLO splices into the game's context menu next to "Properties..." — the copy says: "Open the game's menu (the one with 'Properties...'), select 'Launch Options', and turn ON '<name>' under 'Lyall Fixes'." Do not deep-link DLO's route (unversioned internal). The BepInEx slow-first-boot warning is folded into this modal. Sequence it to not stack with DLO's own confirm modal (verify ordering on device). Uninstall shows the mirror instruction (turn OFF / remove).
+- **Without DLO — degraded manual mode:** when `hasDeckyLaunchOptions` is falsy, a banner recommends installing "Launch Options" from the Decky store, but Install/Update/Uninstall stay enabled (the file-install work — subdir placement, backslash fixes — is value users can't easily replicate by hand). Post-install, a modal shows the exact line `WINEDLLOVERRIDES="<dll>=n,b" %command%` with copy-to-clipboard and instructions to paste it under the game's Properties → Launch Options (precedent: decky-16x10-fixes, Framegen manual mode). The install is marked `launch_option_handled: "manual_pending"` → `status: needs_launch_option` with a per-row "Copy launch option" affordance; cleared best-effort by a **read-only** check of `appDetailsStore.GetAppDetails(appid)?.strLaunchOptions` for the `WINEDLLOVERRIDES="<dll>=` token (no writes — the v1 lock on programmatic writes stands), or by an explicit "I've added it" confirmation. Manual options remain safe if DLO is installed later (DLO preserves and executes originals). *Note: this softens the original "hard-block without DLO" decision; flagged for user sign-off.*
 
 ### Error handling
 
-- Network failures: fall back to cached catalog; per-mod version check failures degrade that row to `unknown` with a retry affordance.
-- Extraction failure mid-way: restore backups and delete files written so far (track as we go), report via toast + `decky.logger`.
-- All backend exceptions bubble to the frontend as JS errors — every callable invocation is try/caught in the API layer and surfaced as a toast.
+Structured results are the only backend→frontend error contract: every callable catches internally and returns `{ok: false, code, message}` — never raises across the bridge. `code` is a small enum (`network_offline`, `verify_failed`, `no_asset`, `extract_failed`, `game_running`, `already_in_progress`, `needs_curation`, `unexpected`); `message` is a short human-written string sized for a toast (~60 chars), e.g. `game_running` → "Close the game before installing", `extract_failed` → "Install failed — game files restored". Full detail goes to `decky.logger` only. The frontend keeps a last-resort try/catch per invocation that toasts "Something went wrong — check the Decky log" and never displays raw exception text. Network failures fall back to the cached catalog.
+
+### Plugin lifecycle
+
+`_uninstall()` leaves installed fixes, manifests, and DLO options in place (removing mods from game dirs during plugin uninstall is surprising and unrecoverable); the README documents this, and Framegen sets the same expectation with an in-UI warning.
 
 ### Repo layout, CI, distribution
 
 - Template-derived layout: `main.py`, `py_modules/lyall_core/` (detection, download, extract, manifest — unit-testable pure Python), `src/`, `plugin.json` (`flags: []`), `package.json`, `defaults/`.
-- GitHub Actions: lint + pytest for `py_modules/lyall_core` (fixture zips: flat, pathed, backslash-entries, zip-slip), `pnpm build`, decky CLI zip build; on tag push, attach the zip to a GitHub release.
+- GitHub Actions: lint + pytest for `py_modules/lyall_core` (fixture zips: flat, pathed, backslash-entries, zip-slip via `..`, absolute-path entries, symlink entries — built programmatically with `ZipInfo.external_attr = 0o120777 << 16` — and over-limit bombs with lying size headers), `pnpm build`, decky CLI zip build; on tag push, attach the zip to a GitHub release.
 - Install URL for users: `https://github.com/sharkusmanch/decky-lyall/releases/latest/download/decky-lyall.zip` via Decky Settings → Developer → Install from URL.
 - Dev loop: rsync to `deck@<ip>:~/homebrew/plugins` + `systemctl restart plugin_loader`; CEF debugging via `chrome://inspect` → `<deck-ip>:8081`.
 
 ### Testing
 
-- Unit tests (CI, no Deck): extractor rules against fixture zips; manifest/uninstall round-trip in a temp dir; vdf/acf parsing against captured Deck fixtures.
-- On-device smoke test (manual): one mod per shape — ClairObscurFix (flat + subdir + dsound), FF7RebirthFix (pathed + dsound), a winmm mod (e.g. MGSVFix), a BepInEx mod (e.g. RaidouFix) — verifying files land next to the shipping exe, DLO import appears, and the fix loads in-game with the toggle on.
+- Unit tests (CI, no Deck): extractor rules against the fixture matrix above (incl. absolute-path/`..`/symlink rejection and resource caps); backup/update/uninstall round-trips (update must preserve pristine backups and remove no-longer-shipped files); manifest pruning; catalog validation rejects (bad mod_id, traversal `install_subdir`, off-host `download_url`, unknown override DLL); every error code returned without an exception escaping a callable.
+- On-device smoke test (manual): one mod per shape — ClairObscurFix (flat + subdir + dsound), FF7RebirthFix (pathed + dsound), a winmm mod (e.g. MGSVFix), a BepInEx mod (e.g. RaidouFix) — verifying files land next to the shipping exe, sha256 verification passes, and the fix loads in-game with the toggle on. DLO choreography: dispatch with QAM open (modal visible/focusable), decline the import and confirm the row warns + "Register launch option" recovers, enable the toggle and confirm the warning clears; verify the instruction copy's menu labels against the DLO **store** build (which lags GitHub).
 
 ## Risks / notes
 
-- `SteamClient`/`appStore` internals are unversioned Valve APIs; the blast radius is limited to display names (worst case: show appids).
-- DLO's store version lags GitHub; the integration event exists since v1.8 but field-level compatibility (e.g. `priority`) should be tested against the store build.
-- Steam game updates can break offset-based fixes until Lyall updates them — the update flow covers recovery, and this is upstream of us.
-- Games on NTFS external drives are a general Proton problem, unrelated to the plugin.
+- `SteamClient`/`appStore` internals are unversioned Valve APIs; blast radius is display names and the read-only manual-mode check (worst case: appids shown, warning not auto-cleared).
+- `~/.dlo/settings.json` is DLO-internal; the probe degrades to `unknown` and `unknown` never warns.
+- DLO's store version lags GitHub; the integration event exists since v1.8 but field-level behavior is verified on-device against the store build.
+- Steam game updates can break offset-based fixes until Lyall updates them — the update flow covers recovery; this is upstream of us.
+- Catalog trust: pinned hashes protect against asset swaps and MITM; a compromised quickfix repo remains a trusted root (mitigated by the human-merged auto-refresh PR gate, verified present).
 
 ## Follow-ups (explicitly out of v1)
 
-1. Use `install_subdir` in Windows `quickfix.py` (fixes the current Layout-B bug where the proxy DLL lands next to the launcher stub).
-2. Upstream DLO feature request: programmatic per-app option enable/remove.
-3. Optional `quickfix-recipes.json` for DLO's Recipes companion plugin as a code-free alternative channel.
+1. Use `install_subdir`/`zip_layout` in Windows `quickfix.py` (fixes the current Layout-B bug where the proxy DLL lands next to the launcher stub).
+2. Upstream DLO feature request: programmatic per-app option enable/remove + an acknowledgment for `dlo-add-launch-options`.
+3. Optional recipes.json for DLO's Recipes companion plugin as a code-free alternative channel.
 4. INI config editor, per-game page integration, background update checks.

--- a/mods.json
+++ b/mods.json
@@ -25,7 +25,8 @@
     ],
     "games": [
       {
-        "steam_appid": 3159330
+        "steam_appid": 3159330,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2026-06-17T23:53:59+02:00",
@@ -44,7 +45,8 @@
     ],
     "games": [
       {
-        "steam_appid": 3123410
+        "steam_appid": 3123410,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-06-04T17:33:34+02:00",
@@ -63,7 +65,8 @@
     ],
     "games": [
       {
-        "steam_appid": 287700
+        "steam_appid": 287700,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2026-06-13T04:14:49+02:00",
@@ -82,7 +85,8 @@
     ],
     "games": [
       {
-        "steam_appid": 1340990
+        "steam_appid": 1340990,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-06-04T17:32:54+02:00",
@@ -161,7 +165,8 @@
     ],
     "games": [
       {
-        "steam_appid": 1902690
+        "steam_appid": 1902690,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-06-04T17:17:18+02:00",
@@ -199,7 +204,8 @@
     ],
     "games": [
       {
-        "steam_appid": 1761390
+        "steam_appid": 1761390,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-06-04T17:15:36+02:00",
@@ -229,7 +235,8 @@
     ],
     "games": [
       {
-        "steam_appid": 2677660
+        "steam_appid": 2677660,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-06-04T17:14:22+02:00",
@@ -338,7 +345,8 @@
     ],
     "games": [
       {
-        "steam_appid": 2535440
+        "steam_appid": 2535440,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-06-04T17:10:00+02:00",
@@ -357,7 +365,8 @@
     ],
     "games": [
       {
-        "steam_appid": 1089090
+        "steam_appid": 1089090,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-06-05T01:01:26+02:00",
@@ -387,7 +396,8 @@
     ],
     "games": [
       {
-        "steam_appid": 2679460
+        "steam_appid": 2679460,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-06-05T01:15:29+02:00",
@@ -447,7 +457,8 @@
     ],
     "games": [
       {
-        "steam_appid": 2515020
+        "steam_appid": 2515020,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-06-05T01:17:00+02:00",
@@ -545,7 +556,8 @@
     ],
     "games": [
       {
-        "steam_appid": 367500
+        "steam_appid": 367500,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-06-21T17:54:29+02:00",
@@ -774,7 +786,8 @@
     ],
     "games": [
       {
-        "steam_appid": 2161700
+        "steam_appid": 2161700,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-08-24T16:28:10+02:00",
@@ -793,7 +806,8 @@
     ],
     "games": [
       {
-        "steam_appid": 1382330
+        "steam_appid": 1382330,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-06-08T21:38:16+02:00",
@@ -877,7 +891,8 @@
     ],
     "games": [
       {
-        "steam_appid": 609150
+        "steam_appid": 609150,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-06-06T15:54:29+02:00",
@@ -1000,7 +1015,8 @@
     ],
     "games": [
       {
-        "steam_appid": 552700
+        "steam_appid": 552700,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-06-08T22:57:21+02:00",
@@ -1039,7 +1055,8 @@
     ],
     "games": [
       {
-        "steam_appid": 3014080
+        "steam_appid": 3014080,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-05-29T20:51:21+02:00",
@@ -1096,7 +1113,8 @@
     ],
     "games": [
       {
-        "steam_appid": 814380
+        "steam_appid": 814380,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-06-09T12:58:30+02:00",
@@ -1115,7 +1133,8 @@
     ],
     "games": [
       {
-        "steam_appid": 1580790
+        "steam_appid": 1580790,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-06-21T17:55:13+02:00",
@@ -1153,7 +1172,8 @@
     ],
     "games": [
       {
-        "steam_appid": 1850570
+        "steam_appid": 1850570,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-07-05T00:31:21+02:00",
@@ -1172,7 +1192,8 @@
     ],
     "games": [
       {
-        "steam_appid": 1448440
+        "steam_appid": 1448440,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-07-18T14:27:40+02:00",
@@ -1251,7 +1272,8 @@
     ],
     "games": [
       {
-        "steam_appid": 1879330
+        "steam_appid": 1879330,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-10-16T04:39:41+02:00",
@@ -1270,7 +1292,8 @@
     ],
     "games": [
       {
-        "steam_appid": 3375780
+        "steam_appid": 3375780,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-10-21T13:42:45+02:00",
@@ -1347,7 +1370,8 @@
     ],
     "games": [
       {
-        "steam_appid": 311730
+        "steam_appid": 311730,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-11-30T23:42:38+01:00",
@@ -1366,7 +1390,8 @@
     ],
     "games": [
       {
-        "steam_appid": 838380
+        "steam_appid": 838380,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2025-12-08T16:29:22+01:00",
@@ -1443,7 +1468,8 @@
     ],
     "games": [
       {
-        "steam_appid": 1325200
+        "steam_appid": 1325200,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2026-02-23T12:01:10+01:00",
@@ -1477,7 +1503,8 @@
     ],
     "games": [
       {
-        "steam_appid": 4198760
+        "steam_appid": 4198760,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2026-03-11T15:32:36+01:00",
@@ -1496,7 +1523,8 @@
     ],
     "games": [
       {
-        "steam_appid": 212630
+        "steam_appid": 212630,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2026-02-14T11:39:00+01:00",
@@ -1534,7 +1562,8 @@
     ],
     "games": [
       {
-        "steam_appid": 3920610
+        "steam_appid": 3920610,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2026-03-13T18:38:35+01:00",
@@ -1553,7 +1582,8 @@
     ],
     "games": [
       {
-        "steam_appid": 3280350
+        "steam_appid": 3280350,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2026-06-12T00:28:14+02:00",
@@ -1572,7 +1602,8 @@
     ],
     "games": [
       {
-        "steam_appid": 2331020
+        "steam_appid": 2331020,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2026-03-31T15:50:00+02:00",
@@ -1610,7 +1641,8 @@
     ],
     "games": [
       {
-        "steam_appid": 798460
+        "steam_appid": 798460,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2026-05-17T22:26:21+02:00",
@@ -1629,7 +1661,8 @@
     ],
     "games": [
       {
-        "steam_appid": 1113560
+        "steam_appid": 1113560,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2026-05-26T20:18:47+02:00",
@@ -1683,7 +1716,8 @@
     ],
     "games": [
       {
-        "steam_appid": 4144680
+        "steam_appid": 4144680,
+        "install_subdir": "."
       }
     ],
     "last_updated": "2026-06-26T05:02:43+02:00",

--- a/scripts/derive_mod_metadata.py
+++ b/scripts/derive_mod_metadata.py
@@ -108,6 +108,8 @@ def collect_warnings(mods):
             warnings.append(f"`{mod_id}`: empty `games[]` — needs a Steam appid")
         for game in mod.get("games", []):
             appid = game.get("steam_appid")
+            # install_subdir "." is the explicit "extract to install root" marker
+            # (README-verified); absence means the target dir is unknown.
             if mod.get("zip_layout") == "flat" and not game.get("install_subdir"):
                 warnings.append(f"`{mod_id}`: flat zip but appid {appid} has no `install_subdir` — installs blocked on Deck")
             if appid in seen_appids and seen_appids[appid] != mod_id:


### PR DESCRIPTION
Follow-up from the full-catalog audit: end-to-end validation of the live catalog showed 41 game entries stuck at `needs_curation` on Deck, because the plugin (correctly) refuses to guess a target directory for flat zips. The audit's README data resolves 34 of them: their READMEs document extraction at the game install root itself.

- Sets `install_subdir: "."` (the explicit "root is correct" marker) on 34 README-verified flat mods — e.g. ACShadowsFix, MGSVFix, SekiroFix, MetaphorFix, DeathStranding2Fix, the Nioh/DOA fixes.
- The remaining 7 uncurated entries are all DragonTweak's non-Infinite-Wealth games, whose exe locations the README genuinely doesn't document — a wrong guess would install a silently inert fix, so they stay blocked until curated.
- decky-lyall `main` (e4b0876) understands the `"."` marker and normalizes it to the install root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)