### PR TITLE
fix: Lost Judgment install_subdir verified on-device (runtime/media)

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -131,7 +131,8 @@
         "steam_appid": 2375550
       },
       {
-        "steam_appid": 2058190
+        "steam_appid": 2058190,
+        "install_subdir": "runtime/media"
       },
       {
         "steam_appid": 1235140


### PR DESCRIPTION
During on-Deck smoke testing, Lost Judgment (2058190) was installed on the test device — its executable is at `runtime/media/LostJudgment.exe`, same layout as Infinite Wealth. One more DragonTweak title unblocked; 6 remain uncurated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)