### PR TITLE
feat: refresh flags newly-supported games in multi-game mods

### DIFF
--- a/scripts/update_mods.py
+++ b/scripts/update_mods.py
@@ -155,6 +155,72 @@ def get_config_files_from_readme(full_name, default_name):
         print(f"  ⚠️ Failed to fetch README ({e}), using default config file")
         return [default_name]
 
+def fetch_readme_text(full_name):
+    """Return the repo's README text, or None."""
+    try:
+        import base64
+        response = codeberg_get(f"{CODEBERG_API}/repos/{full_name}/contents/README.md")
+        response.raise_for_status()
+        return base64.b64decode(response.json()["content"]).decode("utf-8")
+    except Exception:
+        return None
+
+
+def extract_readme_game_names(readme_text):
+    """Game names from the first column of any markdown table (best-effort).
+    Skips header rows ('Game'/'Title'/'Name') and separator rows."""
+    names = []
+    for line in readme_text.splitlines():
+        s = line.strip()
+        if not s.startswith("|"):
+            continue
+        cells = [c.strip() for c in s.strip("|").split("|")]
+        first = cells[0] if cells else ""
+        if not first or set(first) <= set("-: "):
+            continue
+        if first.lower() in ("game", "title", "name"):
+            continue
+        if any(ch.isalpha() for ch in first):
+            names.append(first)
+    return names
+
+
+def steam_search_appid(term):
+    """Top Steam appid for a game name, or None (best-effort — the human verifies)."""
+    try:
+        resp = requests.get(STEAM_SEARCH_API.format(term), timeout=5)
+        resp.raise_for_status()
+        items = resp.json().get("items", [])
+        return items[0].get("id") if items else None
+    except Exception:
+        return None
+
+
+def flag_multigame_gaps(mods, fetch_readme=fetch_readme_text, resolve_appid=steam_search_appid):
+    """For mods covering 2+ games, re-check the README's game table for titles the
+    catalog doesn't have yet. Returns warnings (suggested appids are unverified —
+    a human confirms and adds them). Multi-game mods like DragonTweak accrue new
+    titles upstream that a plain refresh never picks up."""
+    warnings = []
+    for mod_id, mod in mods.items():
+        if len(mod.get("games", [])) < 2:
+            continue
+        readme = fetch_readme(mod["repo"])
+        if not readme:
+            continue
+        have = {g.get("steam_appid") for g in mod["games"]}
+        flagged = set()
+        for name in extract_readme_game_names(readme):
+            if "demo" in name.lower():   # demos are transient; we don't catalog them
+                continue
+            appid = resolve_appid(name)
+            if appid and appid not in have and appid not in flagged:
+                flagged.add(appid)
+                warnings.append(
+                    f"`{mod_id}`: README lists '{name}' (appid {appid}?) not in catalog — verify & add")
+    return warnings
+
+
 def load_existing_mods():
     if os.path.exists("mods.json"):
         with open("mods.json", "r", encoding="utf-8") as f:
@@ -248,6 +314,15 @@ def main():
                     f.write(f"  - [Steam App {game['steam_appid']}](https://store.steampowered.com/app/{game['steam_appid']}/)\n")
         if not added_mods and not updated_mods_ids:
             f.write("No changes detected.\n")
+
+    print("🔎 Re-checking multi-game mods for newly-supported titles...")
+    gaps = flag_multigame_gaps(updated_mods)
+    if gaps:
+        with open("pr_body.md", "a", encoding="utf-8") as f:
+            f.write("\n#### 🎮 Multi-game mods: possible new titles\n")
+            for w in gaps:
+                f.write(f"- {w}\n")
+        print(f"🎮 {len(gaps)} possible new game(s) flagged for review.")
 
     print("✅ mods.json updated successfully.")
     print("✅ pr_body.md generated for pull request.")

--- a/tests/test_multigame.py
+++ b/tests/test_multigame.py
@@ -1,0 +1,74 @@
+from update_mods import extract_readme_game_names, flag_multigame_gaps
+
+TABLE = """# DragonTweak
+Some intro text.
+
+### Current Features
+| Game                           | Feature A | Feature B |
+|--------------------------------|-----------|-----------|
+| Yakuza 0                       | ✔️        | ❌        |
+| Yakuza Kiwami                  | ✔️        | ✔️        |
+| Like a Dragon: Infinite Wealth | ✔️        | ✔️        |
+
+## Installation
+- Extract the zip.
+"""
+
+
+def test_extract_game_names_from_table():
+    assert extract_readme_game_names(TABLE) == [
+        "Yakuza 0", "Yakuza Kiwami", "Like a Dragon: Infinite Wealth"]
+
+
+def test_extract_ignores_header_separator_and_prose():
+    assert extract_readme_game_names("no tables\njust prose") == []
+    # a table whose only rows are header+separator yields nothing
+    assert extract_readme_game_names("| Game |\n|------|\n") == []
+
+
+def test_flag_multigame_gaps_finds_new_game():
+    mods = {
+        "DragonTweak": {"repo": "Lyall/DragonTweak",
+                        "games": [{"steam_appid": 1}, {"steam_appid": 2}]},
+        "SingleFix": {"repo": "Lyall/SingleFix", "games": [{"steam_appid": 9}]},
+    }
+    readmes = {"Lyall/DragonTweak": "| Game |\n|---|\n| GameA |\n| GameB |\n| GameC |\n"}
+    appids = {"GameA": 1, "GameB": 2, "GameC": 3}
+    warns = flag_multigame_gaps(mods, fetch_readme=lambda r: readmes.get(r),
+                                resolve_appid=lambda n: appids.get(n))
+    assert any("GameC" in w and "3" in w for w in warns)
+    assert not any("GameA" in w or "GameB" in w for w in warns)   # already covered
+    assert not any("SingleFix" in w for w in warns)               # single-game skipped
+
+
+def test_flag_skips_missing_readme():
+    mods = {"M": {"repo": "r", "games": [{"steam_appid": 1}, {"steam_appid": 2}]}}
+    assert flag_multigame_gaps(mods, fetch_readme=lambda r: None,
+                               resolve_appid=lambda n: 3) == []
+
+
+def test_flag_ignores_unresolvable_and_already_covered():
+    mods = {"M": {"repo": "r", "games": [{"steam_appid": 1}, {"steam_appid": 2}]}}
+    readmes = {"r": "| Game |\n|---|\n| X |\n| Y |\n"}
+    # X can't be resolved (None), Y resolves to an appid already in the catalog
+    warns = flag_multigame_gaps(mods, fetch_readme=lambda r: readmes[r],
+                                resolve_appid=lambda n: {"Y": 2}.get(n))
+    assert warns == []
+
+
+def test_flag_dedupes_repeated_new_appid():
+    mods = {"M": {"repo": "r", "games": [{"steam_appid": 1}, {"steam_appid": 2}]}}
+    readmes = {"r": "| Game |\n|---|\n| A |\n| A again |\n"}
+    warns = flag_multigame_gaps(mods, fetch_readme=lambda r: readmes[r],
+                                resolve_appid=lambda n: 5)  # both resolve to 5
+    assert len(warns) == 1
+
+
+def test_flag_skips_demo_titles():
+    mods = {"M": {"repo": "r", "games": [{"steam_appid": 1}, {"steam_appid": 2}]}}
+    readmes = {"r": "| Game |\n|---|\n| Cool Game (Demo) |\n| Real Game |\n"}
+    appids = {"Cool Game (Demo)": 100, "Real Game": 200}
+    warns = flag_multigame_gaps(mods, fetch_readme=lambda r: readmes[r],
+                                resolve_appid=lambda n: appids.get(n))
+    assert any("Real Game" in w for w in warns)
+    assert not any("Demo" in w for w in warns)


### PR DESCRIPTION
Closes the systemic gap surfaced by the DragonTweak audit: **multi-game mods accrue new titles upstream that a plain refresh never notices.** DragonTweak's README lists 17 supported games; the catalog had frozen at 8 (RGG shipped Yakuza 0 Director's Cut and new 2025 Kiwami/Kiwami 2 SKUs, plus older Y0/Kiwami/Remaster titles were never added).

The refresh now re-reads the README game table of every mod with 2+ games, resolves each title to a Steam appid, and appends any not already in the catalog to the auto-refresh PR body under "🎮 Multi-game mods: possible new titles."

**Design — flag, don't auto-add.** Suggested appids are best-effort: Steam search returns the newest SKU first (so "Yakuza 0" resolves to the 2025 Director's Cut, missing the 2018 original), and demos would nag every cycle. So each hit is marked "verify & add" for a human to confirm in the PR, never auto-committed — consistent with the catalog's never-guess-silently principle. Demos are filtered out (transient, deliberately not cataloged).

Verified live against the real DragonTweak README — it correctly flags the missing titles. New pure helpers (`extract_readme_game_names`, `flag_multigame_gaps`) are unit-tested with injected fetch/resolve deps (7 tests).

Note: the actual 8 missing DragonTweak games (appids confirmed via Steam appdetails) are added in the companion DragonTweak PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)