### PR TITLE
feat: add 8 newly-supported DragonTweak games (stranded from #64)

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -154,6 +154,30 @@
       {
         "steam_appid": 3061810,
         "install_subdir": "runtime/media"
+      },
+      {
+        "steam_appid": 638970
+      },
+      {
+        "steam_appid": 834530
+      },
+      {
+        "steam_appid": 1088710
+      },
+      {
+        "steam_appid": 1105500
+      },
+      {
+        "steam_appid": 1105510
+      },
+      {
+        "steam_appid": 2988580
+      },
+      {
+        "steam_appid": 3717330
+      },
+      {
+        "steam_appid": 3717340
       }
     ],
     "last_updated": "2026-01-21T21:23:20+01:00",


### PR DESCRIPTION
This commit was pushed to #64's branch after that PR had already merged, so it never landed on master. Re-submitting on its own.

Adds the 8 DragonTweak titles the README supports but the catalog lacked (appids verified via Steam appdetails), taking DragonTweak from 8 → 16 games:

Yakuza 0 (638970), Yakuza Kiwami Legacy (834530), Yakuza 3/4/5 Remastered (1088710/1105500/1105510), Yakuza 0 Director's Cut (2988580), Yakuza Kiwami 2025 (3717330), Yakuza Kiwami 2 2025 (3717340). Kiwami 3 demo (3948220) excluded.

No `install_subdir` — on Deck these surface via the "Detect fix location" flow (the root-vs-`runtime/media` split among Yakuza titles means paths shouldn't be guessed). #65's refresh check will keep this gap from recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)