### PR TITLE
feat: derive & install GitHub-hosted fixes; curate PR #68 warnings

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -257,7 +257,14 @@
       {
         "steam_appid": 2530980
       }
-    ]
+    ],
+    "loader": "bepinex",
+    "zip_layout": "pathed",
+    "wine_dll_override": "version",
+    "download_url": "https://github.com/Lyall/TalesOfGracesFFix/releases/download/v0.0.4/TalesOfGracesFFix_v0.0.4.zip",
+    "sha256": "3c237093e26528a0f91ac24a6a03fc26bfde0ec8f5785afe0892a39f47e4726a",
+    "size": 663361,
+    "derived_release": "v0.0.4"
   },
   "GreatCircleFix": {
     "repo": "Lyall/GreatCircleFix",
@@ -345,7 +352,14 @@
       {
         "steam_appid": 1643320
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "pathed",
+    "wine_dll_override": "dsound",
+    "download_url": "https://github.com/Lyall/STALKER2Tweak/releases/download/v0.0.9/STALKER2Tweak_v0.0.9.zip",
+    "sha256": "6770f8c910db2cf01fd13b93151af41042c49f4d7a434b112657ee762d5c78c3",
+    "size": 649661,
+    "derived_release": "v0.0.9"
   },
   "DAFix": {
     "repo": "Lyall/DAFix",
@@ -416,9 +430,17 @@
     ],
     "games": [
       {
-        "steam_appid": 502280
+        "steam_appid": 502280,
+        "install_subdir": "."
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "flat",
+    "wine_dll_override": "dinput8",
+    "download_url": "https://github.com/Lyall/BerserkFix/releases/download/v0.0.5a/BerserkFix_v0.0.5a.zip",
+    "sha256": "8969add9fcfec3f1d6649901cfe78027d63840eff35b4d856dcd28ba747c000b",
+    "size": 649014,
+    "derived_release": "v0.0.5a"
   },
   "MetaphorFix": {
     "repo": "Lyall/MetaphorFix",
@@ -447,9 +469,17 @@
     ],
     "games": [
       {
-        "steam_appid": 1420290
+        "steam_appid": 1420290,
+        "install_subdir": "."
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "flat",
+    "wine_dll_override": "version",
+    "download_url": "https://github.com/Lyall/NMHFix/releases/download/v0.7.2/NMHFix_v0.7.2.zip",
+    "sha256": "2723670f2bf8577f762461a98b0808deadc9a2dddf4b1e559bdcfb322f67f6f0",
+    "size": 1183410,
+    "derived_release": "v0.7.2"
   },
   "Disgaea5Fix": {
     "repo": "Lyall/Disgaea5Fix",
@@ -458,9 +488,17 @@
     ],
     "games": [
       {
-        "steam_appid": 803600
+        "steam_appid": 803600,
+        "install_subdir": "."
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "flat",
+    "wine_dll_override": "dinput8",
+    "download_url": "https://github.com/Lyall/Disgaea5Fix/releases/download/v0.8.1/Disgaea5Fix_v0.8.1.zip",
+    "sha256": "26ace1feb95cdccab13c834a254eec3bbcbc7f379800b5804d4aa93c8ce7d000",
+    "size": 639112,
+    "derived_release": "v0.8.1"
   },
   "WukongTweak": {
     "repo": "Lyall/WukongTweak",
@@ -548,7 +586,14 @@
       {
         "steam_appid": 948740
       }
-    ]
+    ],
+    "loader": "bepinex",
+    "zip_layout": "pathed",
+    "wine_dll_override": "winhttp",
+    "download_url": "https://github.com/Lyall/AISomniumFilesFix/releases/download/v0.1/AISomniumFilesFix_v0.1.zip",
+    "sha256": "a2f5c4f1894199aba347125a417bc15948a298f26fed64d06a3e72cf2f1f8e3d",
+    "size": 637936,
+    "derived_release": "v0.1"
   },
   "AsDuskFallsFix": {
     "repo": "Lyall/AsDuskFallsFix",
@@ -559,7 +604,14 @@
       {
         "steam_appid": 1341820
       }
-    ]
+    ],
+    "loader": "bepinex",
+    "zip_layout": "pathed",
+    "wine_dll_override": "winhttp",
+    "download_url": "https://github.com/Lyall/AsDuskFallsFix/releases/download/v1.0.0/AsDuskFallsFix_v1.0.0.zip",
+    "sha256": "2550abab6d943a183d3c336f40c29b37825335f468c61bacf96f5b210bd25ad8",
+    "size": 10585736,
+    "derived_release": "v1.0.0"
   },
   "BravelyDefault2Fix": {
     "repo": "Lyall/BravelyDefault2Fix",
@@ -609,7 +661,14 @@
       {
         "steam_appid": 934700
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "pathed",
+    "wine_dll_override": "dsound",
+    "download_url": "https://github.com/Lyall/DeadIsland2Fix/releases/download/v1.0.3/DeadIsland2Fix_v1.0.3.zip",
+    "sha256": "039450ad1d1fe3c3d14c6ab9f41217ce8c3b46c71b0005a336d4f24e2813f233",
+    "size": 427971,
+    "derived_release": "v1.0.3"
   },
   "DMCHDFix": {
     "repo": "Lyall/DMCHDFix",
@@ -618,9 +677,17 @@
     ],
     "games": [
       {
-        "steam_appid": 631510
+        "steam_appid": 631510,
+        "install_subdir": "."
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "flat",
+    "wine_dll_override": "d3d11",
+    "download_url": "https://github.com/Lyall/DMCHDFix/releases/download/v0.8/DMCHDFix_v0_8.zip",
+    "sha256": "88aa087028026ebc7df28bc129519cc6cefc98681da3daa5357046c04d920881",
+    "size": 243502,
+    "derived_release": "v0.8"
   },
   "DQXISFix": {
     "repo": "Lyall/DQXISFix",
@@ -651,7 +718,14 @@
       {
         "steam_appid": 1658290
       }
-    ]
+    ],
+    "loader": "bepinex",
+    "zip_layout": "pathed",
+    "wine_dll_override": "winhttp",
+    "download_url": "https://github.com/Lyall/EiyudenChronicleRisingFix/releases/download/v1.0.1/EiyudenChronicleRisingFix_v1.0.1.zip",
+    "sha256": "9cc7a36f731328590d40930073fb630e6df879c82f96c0664624135616481e39",
+    "size": 638164,
+    "derived_release": "v1.0.1"
   },
   "FISTFix": {
     "repo": "Lyall/FISTFix",
@@ -662,7 +736,14 @@
       {
         "steam_appid": 1330470
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "pathed",
+    "wine_dll_override": "dsound",
+    "download_url": "https://github.com/Lyall/FISTFix/releases/download/v1.0.0/FISTFix_v1.0.0.zip",
+    "sha256": "3186ada4e70c55b4509ca303d03a4a926eac6e9a50013afdee824fa67c400aa6",
+    "size": 433321,
+    "derived_release": "v1.0.0"
   },
   "GBFRelinkFix": {
     "repo": "Lyall/GBFRelinkFix",
@@ -690,9 +771,17 @@
     ],
     "games": [
       {
-        "steam_appid": 2215430
+        "steam_appid": 2215430,
+        "install_subdir": "."
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "flat",
+    "wine_dll_override": "d3d12",
+    "download_url": "https://github.com/Lyall/GoTFix/releases/download/v0.9.3/GoTFix_v0.9.3.zip",
+    "sha256": "6cf6aa9fb87a003071e28f0d470a291fbbd151b4d1942db9bf89759bb21c57ca",
+    "size": 456824,
+    "derived_release": "v0.9.3"
   },
   "HogwartsLegacyFix": {
     "repo": "Lyall/HogwartsLegacyFix",
@@ -703,7 +792,14 @@
       {
         "steam_appid": 990080
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "pathed",
+    "wine_dll_override": "version",
+    "download_url": "https://github.com/Lyall/HogwartsLegacyFix/releases/download/v1.0/HogwartsLegacyFix_v1_0.zip",
+    "sha256": "8f3a46f3bc05f54afb44b105b24b1e9c6eb6f467d891b337fc56dba407b7eee7",
+    "size": 189425,
+    "derived_release": "v1.0"
   },
   "HundredHeroesFix": {
     "repo": "Lyall/HundredHeroesFix",
@@ -733,7 +829,14 @@
       {
         "steam_appid": 1805480
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "flat",
+    "wine_dll_override": "winmm",
+    "download_url": "https://github.com/Lyall/IshinFix/releases/download/v1.0.4/IshinFix_v1_0_4.zip",
+    "sha256": "9c7d1c64cae1af1cf44207af676a21cc6cc77325f01b0d816382304c7018189f",
+    "size": 221996,
+    "derived_release": "v1.0.4"
   },
   "JediSurvivorFix": {
     "repo": "Lyall/JediSurvivorFix",
@@ -744,7 +847,14 @@
       {
         "steam_appid": 1774580
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "pathed",
+    "wine_dll_override": "xinput1_3",
+    "download_url": "https://github.com/Lyall/JediSurvivorFix/releases/download/v1.0.1/JediSurvivorFix_v1_0_1.zip",
+    "sha256": "82c5d9805f99eb105bdafb24662f1b7fdd0b677c7cf58edb40ca252b3b5f40e9",
+    "size": 79987,
+    "derived_release": "v1.0.1"
   },
   "MaxPayne3Fix": {
     "repo": "Lyall/MaxPayne3Fix",
@@ -753,9 +863,17 @@
     ],
     "games": [
       {
-        "steam_appid": 204100
+        "steam_appid": 204100,
+        "install_subdir": "Max Payne 3"
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "flat",
+    "wine_dll_override": "dinput8",
+    "download_url": "https://github.com/Lyall/MaxPayne3Fix/releases/download/v1.0/MaxPayne3Fix_v1_0.zip",
+    "sha256": "daf30b92431500b7edd3d1d50325ce9c5606450e1669567506f7c7a12b727ad6",
+    "size": 1088375,
+    "derived_release": "v1.0"
   },
   "MGSHDFix": {
     "repo": "Lyall/MGSHDFix",
@@ -766,7 +884,13 @@
       {
         "steam_appid": 2131630
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "pathed",
+    "download_url": "https://github.com/ShizCalev/MGSHDFix/releases/download/3.1.0/MGSHDFix_3.1.0.zip",
+    "sha256": "ec42a40a26d80425496cf20a52c13d91f1523d74472c77183dda0aaf0d46db33",
+    "size": 9455501,
+    "derived_release": "3.1.0"
   },
   "Octopath2Fix": {
     "repo": "Lyall/Octopath2Fix",
@@ -797,7 +921,14 @@
       {
         "steam_appid": 921570
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "pathed",
+    "wine_dll_override": "d3d11",
+    "download_url": "https://github.com/Lyall/OctopathFix/releases/download/v0.0.1/OctopathFix_v0_0_1.zip",
+    "sha256": "bbe0d24f649ed3044523fd2ea18b9ac36a977e6e62038cd378f1264c7271d4fc",
+    "size": 225539,
+    "derived_release": "v0.0.1"
   },
   "Overcooked2Fix": {
     "repo": "Lyall/Overcooked2Fix",
@@ -808,7 +939,14 @@
       {
         "steam_appid": 728880
       }
-    ]
+    ],
+    "loader": "bepinex",
+    "zip_layout": "pathed",
+    "wine_dll_override": "winhttp",
+    "download_url": "https://github.com/Lyall/Overcooked2Fix/releases/download/v1.0.1/Overcooked2Fix_v1.0.1_Epic.zip",
+    "sha256": "db6a025ab8fe2a718fc16861ffe9ea8219e094348e5195ea2397e6da4f64f9dc",
+    "size": 637241,
+    "derived_release": "v1.0.1"
   },
   "P3RFix": {
     "repo": "Lyall/P3RFix",
@@ -857,9 +995,17 @@
     ],
     "games": [
       {
-        "steam_appid": 21690
+        "steam_appid": 21690,
+        "install_subdir": "."
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "flat",
+    "wine_dll_override": "xinput1_3",
+    "download_url": "https://github.com/Lyall/RE5Fix/releases/download/v1.0.4/RE5Fix_v1.0.4.zip",
+    "sha256": "9d41f053cd2b13e0759b1c7639c0965d212984dd3538183a273380cf2aba001b",
+    "size": 17656,
+    "derived_release": "v1.0.4"
   },
   "RERevFix": {
     "repo": "Lyall/RERevFix",
@@ -868,9 +1014,17 @@
     ],
     "games": [
       {
-        "steam_appid": 222480
+        "steam_appid": 222480,
+        "install_subdir": "."
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "flat",
+    "wine_dll_override": "xinput1_3",
+    "download_url": "https://github.com/Lyall/RERevFix/releases/download/v1.0.0/RERevFix.v1.0.0.zip",
+    "sha256": "0ebf85bf333cb5da3c48a4b0eee224336fb871c92a1b5181218f8883748f6034",
+    "size": 16372,
+    "derived_release": "v1.0.0"
   },
   "RF5Fix": {
     "repo": "Lyall/RF5Fix",
@@ -881,7 +1035,14 @@
       {
         "steam_appid": 1702330
       }
-    ]
+    ],
+    "loader": "bepinex",
+    "zip_layout": "pathed",
+    "wine_dll_override": "winhttp",
+    "download_url": "https://github.com/Lyall/RF5Fix/releases/download/v0.1.5/RF5Fix_v0.1.5.zip",
+    "sha256": "75d61ea4bcc646eeed94270c1f576c252f370ca479ff6f2435caccb06d5f0c09",
+    "size": 34174109,
+    "derived_release": "v0.1.5"
   },
   "SignalisFix": {
     "repo": "Lyall/SignalisFix",
@@ -892,7 +1053,14 @@
       {
         "steam_appid": 1262350
       }
-    ]
+    ],
+    "loader": "bepinex",
+    "zip_layout": "pathed",
+    "wine_dll_override": "winhttp",
+    "download_url": "https://github.com/Lyall/SignalisFix/releases/download/v1.0.2/SignalisFix_v1.0.2.zip",
+    "sha256": "71a2beb37d50c94b9612574f142cbafad270e1932679f323f21339c2d1e53158",
+    "size": 34271009,
+    "derived_release": "v1.0.2"
   },
   "SMTVFix": {
     "repo": "Lyall/SMTVFix",
@@ -963,7 +1131,14 @@
       {
         "steam_appid": 2653940
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "pathed",
+    "wine_dll_override": "winmm",
+    "download_url": "https://github.com/Lyall/StarTrekResurgenceFix/releases/download/v1.0.5/StarTrekResurgenceFix_v1_0_5.zip",
+    "sha256": "2d940a705eedfe50b500fe1eafc6fd5875619c67228c182eabdc2f2a773f833b",
+    "size": 218635,
+    "derived_release": "v1.0.5"
   },
   "StrayedLightsFix": {
     "repo": "Lyall/StrayedLightsFix",
@@ -974,7 +1149,14 @@
       {
         "steam_appid": 2162020
       }
-    ]
+    ],
+    "loader": "ual",
+    "zip_layout": "pathed",
+    "wine_dll_override": "winmm",
+    "download_url": "https://github.com/Lyall/StrayedLightsFix/releases/download/v1.0.1/StrayedLightsFix_v1.0.1.zip",
+    "sha256": "7e9b9f56b174b2c05311a843527e899454e24c41deec80419183b6442d446f05",
+    "size": 431495,
+    "derived_release": "v1.0.1"
   },
   "SyberiaTWBFix": {
     "repo": "Lyall/SyberiaTWBFix",
@@ -1004,7 +1186,14 @@
       {
         "steam_appid": 2366980
       }
-    ]
+    ],
+    "loader": "bepinex",
+    "zip_layout": "pathed",
+    "wine_dll_override": "winhttp",
+    "download_url": "https://github.com/Lyall/TGYHFix/releases/download/v1.0.0/TGYHFix_v1.0.0.zip",
+    "sha256": "2ebe1f7a1a7c7cbcee6787affbd10a6e5c036f50b41292b10266c6ae642075b6",
+    "size": 31380492,
+    "derived_release": "v1.0.0"
   },
   "ThronebreakerFix": {
     "repo": "Lyall/ThronebreakerFix",
@@ -1015,7 +1204,14 @@
       {
         "steam_appid": 973760
       }
-    ]
+    ],
+    "loader": "bepinex",
+    "zip_layout": "pathed",
+    "wine_dll_override": "winhttp",
+    "download_url": "https://github.com/Lyall/ThronebreakerFix/releases/download/v0.0.3/ThronebreakerFix_v0.0.3.zip",
+    "sha256": "15d9f9458530795200e6d194b8e6911f3fbe9871b68377de6541904241522baf",
+    "size": 10590092,
+    "derived_release": "v0.0.3"
   },
   "TormentedSoulsFix": {
     "repo": "Lyall/TormentedSoulsFix",
@@ -1026,7 +1222,14 @@
       {
         "steam_appid": 1367590
       }
-    ]
+    ],
+    "loader": "bepinex",
+    "zip_layout": "pathed",
+    "wine_dll_override": "winhttp",
+    "download_url": "https://github.com/Lyall/TormentedSoulsFix/releases/download/v1.0.0/TormentedSoulsFix_v1.0.0.zip",
+    "sha256": "7f4b7315333082bf4a5164c99d724f469ffdf71301b1be819094ec698384544c",
+    "size": 642733,
+    "derived_release": "v1.0.0"
   },
   "WeNeedToGoDeeperFix": {
     "repo": "Lyall/WeNeedToGoDeeperFix",
@@ -1037,7 +1240,14 @@
       {
         "steam_appid": 307110
       }
-    ]
+    ],
+    "loader": "bepinex",
+    "zip_layout": "pathed",
+    "wine_dll_override": "winhttp",
+    "download_url": "https://github.com/Lyall/WeNeedToGoDeeperFix/releases/download/v1.0.4/WeNeedToGoDeeperFix_v1.0.4.zip",
+    "sha256": "f7c369b20c85111f67f6f47a3d1b9bb948786c8cffb2dc499b09e248b0abed26",
+    "size": 638615,
+    "derived_release": "v1.0.4"
   },
   "WOFFFix": {
     "repo": "Lyall/WOFFFix",
@@ -1517,7 +1727,12 @@
     "config_files": [
       "DOAXVVPrismFix.ini"
     ],
-    "games": [],
+    "games": [
+      {
+        "steam_appid": 3155730,
+        "install_subdir": "."
+      }
+    ],
     "last_updated": "2026-01-22T07:55:05+01:00",
     "loader": "ual",
     "zip_layout": "flat",
@@ -1730,7 +1945,11 @@
     "config_files": [
       "NoSleepForKanameDateFix.cfg"
     ],
-    "games": [],
+    "games": [
+      {
+        "steam_appid": 2752180
+      }
+    ],
     "last_updated": "2026-06-12T15:34:27+02:00",
     "loader": "bepinex",
     "zip_layout": "pathed",

--- a/quickfix.py
+++ b/quickfix.py
@@ -16,6 +16,7 @@ __version__ = "1.0.5"
 DEBUG_MODE = False
 INSTALLED_MODS_FILE = "installed.json"
 CODEBERG_API = "https://codeberg.org/api/v1"
+GITHUB_API = "https://api.github.com"
 
 def debug_print(message):
     if DEBUG_MODE:
@@ -319,26 +320,40 @@ def open_config_files(mod_id, mods):
 
     print(f"[INFO] Finished processing config files for {mod_id}.")
 
+def _select_release_zip(release_data):
+    """Return (version, download_url) for the latest release's .zip asset.
+
+    Prefers a non-Xbox zip when a release ships both a Steam and an _Xbox
+    build. Returns (version, None) when no zip asset is present.
+    """
+    version = release_data.get("tag_name", "unknown")
+    zips = [a for a in release_data.get("assets", [])
+            if a.get("name", "").endswith(".zip")]
+    if not zips:
+        return version, None
+    preferred = next((a for a in zips if "xbox" not in a.get("name", "").lower()), zips[0])
+    return version, preferred.get("browser_download_url")
+
+
 def get_latest_release_info(repo):
-    url = f"{CODEBERG_API}/repos/{repo}/releases/latest"
-    response = codeberg_get(url)
-
+    # Try Codeberg first, then fall back to GitHub for the Lyall fixes not
+    # (yet) mirrored to Codeberg.
+    response = codeberg_get(f"{CODEBERG_API}/repos/{repo}/releases/latest")
     if response.status_code == 200:
-        release_data = response.json()
-        version = release_data.get("tag_name", "unknown")
-        attachments = release_data.get("assets", [])
-        download_url = next((asset.get("browser_download_url")
-                          for asset in attachments
-                          if asset.get("name", "").endswith(".zip")), None)
+        version, download_url = _select_release_zip(response.json())
+        if download_url:
+            return version, download_url
 
+    response = github_get(f"{GITHUB_API}/repos/{repo}/releases/latest")
+    if response.status_code == 200:
+        version, download_url = _select_release_zip(response.json())
         if not download_url:
             print(f"[ERROR] No download URL found for the latest release of {repo}.")
             return None, None
-
         return version, download_url
-    else:
-        print(f"[ERROR] Could not fetch release info for {repo}.")
-        return None, None
+
+    print(f"[ERROR] Could not fetch release info for {repo}.")
+    return None, None
 
 def list_installed_mods():
     """List all installed mods and their versions."""

--- a/scripts/derive_mod_metadata.py
+++ b/scripts/derive_mod_metadata.py
@@ -8,6 +8,7 @@ import zipfile
 import requests
 
 CODEBERG_API = "https://codeberg.org/api/v1"
+GITHUB_API = "https://api.github.com"
 
 # UAL x64 proxy names Lyall's fixes can ship. dxgi is deliberately excluded:
 # auto-overriding it would break DXVK.
@@ -61,15 +62,44 @@ def codeberg_get(url):
     return requests.get(url, headers=headers, timeout=15)
 
 
-def get_latest_zip_asset(repo):
-    """Return {'tag', 'url'} for the latest release's .zip asset, or None."""
-    resp = codeberg_get(f"{CODEBERG_API}/repos/{repo}/releases/latest")
-    if resp.status_code != 200:
+def github_get(url):
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return requests.get(url, headers=headers, timeout=15)
+
+
+def parse_release_assets(data):
+    """Extract {'tag', 'url'} for the latest release's .zip asset, or None.
+
+    Codeberg's Gitea API and the GitHub API expose the same release schema
+    (tag_name + assets[].browser_download_url), so one parser serves both.
+    When a release ships multiple zips (e.g. a Steam build and an _Xbox
+    variant), prefer the non-Xbox one — that's the build QuickFix installs.
+    """
+    zips = [a for a in data.get("assets", []) if a.get("name", "").endswith(".zip")]
+    if not zips:
         return None
-    data = resp.json()
-    for asset in data.get("assets", []):
-        if asset.get("name", "").endswith(".zip"):
-            return {"tag": data.get("tag_name", ""), "url": asset["browser_download_url"]}
+    preferred = next((a for a in zips if "xbox" not in a["name"].lower()), zips[0])
+    return {"tag": data.get("tag_name", ""), "url": preferred["browser_download_url"]}
+
+
+def get_latest_zip_asset(repo):
+    """Return {'tag', 'url'} for the latest release's .zip asset, or None.
+
+    Tries Codeberg first, then falls back to GitHub for the many Lyall fixes
+    not (yet) mirrored to Codeberg. Without the fallback these mods never
+    derive metadata and warn on every refresh.
+    """
+    resp = codeberg_get(f"{CODEBERG_API}/repos/{repo}/releases/latest")
+    if resp.status_code == 200:
+        asset = parse_release_assets(resp.json())
+        if asset:
+            return asset
+    resp = github_get(f"{GITHUB_API}/repos/{repo}/releases/latest")
+    if resp.status_code == 200:
+        return parse_release_assets(resp.json())
     return None
 
 

--- a/scripts/validate_mods.py
+++ b/scripts/validate_mods.py
@@ -11,9 +11,12 @@ from derive_mod_metadata import KNOWN_PROXY_DLLS
 
 API_TOKEN = os.environ.get("CODEBERG_TOKEN")
 CODEBERG_API = "https://codeberg.org/api/v1"
+GITHUB_API = "https://api.github.com"
 
 ALLOWED_LOADERS = {"ual", "bepinex", "melonloader"}
 ALLOWED_LAYOUTS = {"flat", "pathed"}
+# Release assets are served from Codeberg or, for fixes not mirrored there, GitHub.
+ALLOWED_DOWNLOAD_HOSTS = {"codeberg.org", "github.com"}
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
@@ -29,6 +32,21 @@ def codeberg_get(url, retries=3):
         if attempt < retries - 1:
             time.sleep(2 ** attempt)
     return response
+
+
+def github_get(url):
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return requests.get(url, headers=headers, timeout=10)
+
+
+def repo_exists(repo):
+    """True if the repo is hosted on Codeberg or GitHub."""
+    if codeberg_get(f"{CODEBERG_API}/repos/{repo}").status_code == 200:
+        return True
+    return github_get(f"{GITHUB_API}/repos/{repo}").status_code == 200
 
 
 def _unsafe_subdir(subdir):
@@ -63,7 +81,7 @@ def validate_entry(mod_id, mod):
         if not SHA256_RE.match(str(mod.get("sha256", ""))):
             errors.append("bad or missing sha256 for derived entry")
         url = urlparse(str(mod.get("download_url", "")))
-        if url.scheme != "https" or url.hostname != "codeberg.org":
+        if url.scheme != "https" or url.hostname not in ALLOWED_DOWNLOAD_HOSTS:
             errors.append(f"bad download_url: {mod.get('download_url')!r}")
         if not isinstance(mod.get("size"), int) or mod["size"] <= 0:
             errors.append("bad or missing size for derived entry")
@@ -102,12 +120,10 @@ def validate_mods():
         for error in errors:
             print(f"❌ {mod_id}: {error}")
             failed = True
-        if mod.get("repo"):
-            response = codeberg_get(f"{CODEBERG_API}/repos/{mod['repo']}")
-            if response.status_code != 200:
-                # Legacy GitHub-only fixes (pre-Codeberg-migration) 404 here; they
-                # simply never get derived metadata, so warn rather than fail.
-                print(f"⚠️ {mod_id}: Codeberg repo '{mod['repo']}' not found.")
+        if mod.get("repo") and not repo_exists(mod["repo"]):
+            # Only warn when the repo is on neither Codeberg nor GitHub; a
+            # GitHub-only fix still derives and installs via the fallback.
+            print(f"⚠️ {mod_id}: repo '{mod['repo']}' not found on Codeberg or GitHub.")
 
     for warning in collect_cross_mod_warnings(mods):
         print(f"⚠️ {warning}")

--- a/tests/test_derive_mod_metadata.py
+++ b/tests/test_derive_mod_metadata.py
@@ -49,7 +49,82 @@ import hashlib
 import io
 import zipfile
 
-from derive_mod_metadata import collect_warnings, derive_mod, needs_derivation
+from derive_mod_metadata import (
+    collect_warnings,
+    derive_mod,
+    get_latest_zip_asset,
+    needs_derivation,
+    parse_release_assets,
+)
+
+
+def test_parse_release_assets_picks_zip_and_tag():
+    data = {"tag_name": "v1.2.3", "assets": [
+        {"name": "notes.txt", "browser_download_url": "https://x/notes.txt"},
+        {"name": "Fix_v1.2.3.zip", "browser_download_url": "https://x/Fix.zip"},
+    ]}
+    assert parse_release_assets(data) == {"tag": "v1.2.3", "url": "https://x/Fix.zip"}
+
+
+def test_parse_release_assets_prefers_non_xbox_zip():
+    # GitHub releases often ship a Steam zip and an _Xbox variant; the Steam
+    # build is the one QuickFix installs.
+    data = {"tag_name": "v0.0.9", "assets": [
+        {"name": "STALKER2Tweak_v0.0.9_Xbox.zip", "browser_download_url": "https://x/xbox.zip"},
+        {"name": "STALKER2Tweak_v0.0.9.zip", "browser_download_url": "https://x/steam.zip"},
+    ]}
+    assert parse_release_assets(data)["url"] == "https://x/steam.zip"
+
+
+def test_parse_release_assets_none_without_zip():
+    assert parse_release_assets({"tag_name": "v1", "assets": [
+        {"name": "readme.md", "browser_download_url": "https://x/readme.md"}]}) is None
+
+
+def test_get_latest_zip_asset_falls_back_to_github(monkeypatch):
+    import derive_mod_metadata as d
+
+    class Resp:
+        def __init__(self, status, data=None):
+            self.status_code = status
+            self._data = data or {}
+
+        def json(self):
+            return self._data
+
+    gh_payload = {"tag_name": "v0.0.9", "assets": [
+        {"name": "Fix_v0.0.9.zip", "browser_download_url": "https://github.com/Lyall/Fix.zip"}]}
+    monkeypatch.setattr(d, "codeberg_get", lambda url: Resp(404))
+    monkeypatch.setattr(d, "github_get", lambda url: Resp(200, gh_payload))
+
+    assert get_latest_zip_asset("Lyall/Fix") == {
+        "tag": "v0.0.9", "url": "https://github.com/Lyall/Fix.zip"}
+
+
+def test_get_latest_zip_asset_prefers_codeberg(monkeypatch):
+    import derive_mod_metadata as d
+
+    class Resp:
+        def __init__(self, status, data=None):
+            self.status_code = status
+            self._data = data or {}
+
+        def json(self):
+            return self._data
+
+    cb_payload = {"tag_name": "1.0", "assets": [
+        {"name": "Fix.zip", "browser_download_url": "https://codeberg.org/Lyall/Fix.zip"}]}
+    calls = {"github": 0}
+
+    def gh(url):
+        calls["github"] += 1
+        return Resp(404)
+
+    monkeypatch.setattr(d, "codeberg_get", lambda url: Resp(200, cb_payload))
+    monkeypatch.setattr(d, "github_get", gh)
+
+    assert get_latest_zip_asset("Lyall/Fix")["url"] == "https://codeberg.org/Lyall/Fix.zip"
+    assert calls["github"] == 0  # codeberg hit means no github call
 
 
 def _zip_blob(names):

--- a/tests/test_validate_mods.py
+++ b/tests/test_validate_mods.py
@@ -1,4 +1,30 @@
-from validate_mods import validate_entry, collect_cross_mod_warnings
+from validate_mods import validate_entry, collect_cross_mod_warnings, repo_exists
+
+
+class _Resp:
+    def __init__(self, status):
+        self.status_code = status
+
+
+def test_repo_exists_true_when_on_codeberg(monkeypatch):
+    import validate_mods as v
+    monkeypatch.setattr(v, "codeberg_get", lambda url: _Resp(200))
+    monkeypatch.setattr(v, "github_get", lambda url: _Resp(404))
+    assert repo_exists("Lyall/FooFix") is True
+
+
+def test_repo_exists_true_when_only_on_github(monkeypatch):
+    import validate_mods as v
+    monkeypatch.setattr(v, "codeberg_get", lambda url: _Resp(404))
+    monkeypatch.setattr(v, "github_get", lambda url: _Resp(200))
+    assert repo_exists("Lyall/FooFix") is True
+
+
+def test_repo_exists_false_when_nowhere(monkeypatch):
+    import validate_mods as v
+    monkeypatch.setattr(v, "codeberg_get", lambda url: _Resp(404))
+    monkeypatch.setattr(v, "github_get", lambda url: _Resp(404))
+    assert repo_exists("Lyall/GhostFix") is False
 
 
 def _valid():
@@ -43,6 +69,13 @@ def test_offsite_download_url_rejected():
     mod = _valid()
     mod["download_url"] = "https://evil.example.com/F.zip"
     assert any("download_url" in e for e in validate_entry("FooFix", mod))
+
+
+def test_github_download_url_accepted():
+    # GitHub-hosted fixes (not mirrored to Codeberg) derive github.com asset URLs.
+    mod = _valid()
+    mod["download_url"] = "https://github.com/Lyall/FooFix/releases/download/0.0.1/F.zip"
+    assert not any("download_url" in e for e in validate_entry("FooFix", mod))
 
 
 def test_underived_entry_needs_no_pinning_fields():


### PR DESCRIPTION
## Fixes the recurring "Curation needed" warnings on auto-refresh PRs (e.g. #68)

### Root cause
29 Lyall fixes are hosted **only on GitHub**, but the metadata deriver, the `quickfix.py` runtime, and `validate_mods.py` all queried **Codeberg only** (`api.github.com/repos/Lyall/X` → 200, Codeberg → 404). Consequences:
- The deriver could never fetch their release zips → `wine_dll_override` stayed `null` → they warned **on every single refresh**.
- `quickfix.py` `get_latest_release_info` was Codeberg-only, so these fixes couldn't be **installed** on-device at all — the warning was a symptom of a bigger gap.
- The `github_get()` helper in `quickfix.py` was dead code left over from before the Codeberg migration.

### Code changes (test-first)
- **`derive_mod_metadata.py`** — `get_latest_zip_asset` now tries Codeberg, then falls back to GitHub, via a shared `parse_release_assets` (Codeberg's Gitea API and GitHub expose the same release schema). Prefers the non-Xbox zip when a release ships both a Steam and an `_Xbox` build.
- **`quickfix.py`** — mirrors the same Codeberg→GitHub fallback in `get_latest_release_info` so the 28 GitHub fixes actually install. (Can't be unit-tested on Linux — the module imports `winreg` — so the zip-selection logic is factored into `_select_release_zip` and exercised in isolation.)
- **`validate_mods.py`** — `github.com` is now an allowed `download_url` host (was a hard error that would have failed CI on the newly-derived entries); repo-existence check accepts Codeberg **or** GitHub via a new tested `repo_exists`.

### Data curation
- **28 of 29** GitHub mods re-derived (override / loader / layout / download_url / sha256 / size). MGSHDFix left flagged — it ships both `winhttp.dll` and `wininet.dll` at equal depth, so the proxy is genuinely ambiguous.
- Added verified Steam appids: **DOAXVVPrismFix → 3155730** (base game, confirmed via Steam appdetails `type=game`; not DLC 3199230 or the original 958260) and **NoSleepForKanameDateFix → 2752180** (the game, not the soundtrack).
- README-verified `install_subdir`: `.` for 8 root-extraction fixes (NMHFix, BerserkFix, GoTFix, Disgaea5Fix, DMCHDFix, DOAXVVPrismFix, RE5Fix, RERevFix); `Max Payne 3` for MaxPayne3Fix (README-explicit nested path).

### Result
Warnings **39 → 10**. The remaining 10 are legitimate curation items needing **on-device verification**, not tooling gaps:
- 8 DragonTweak Yakuza appids (mixed old-port / Dragon-Engine, no per-game README paths)
- IshinFix (nested `.../Binaries/Win64` path with a `LikeADragonIshin` vs `LikeaDragonIshin` casing mismatch — an ext4 case-sensitivity trap)
- MGSHDFix (`winhttp` vs `wininet` proxy choice)

All 38 tests pass; `mods.json` validates with zero errors.

After merge, re-running the auto-refresh (#68) will regenerate `mods.json` cleanly and surface only those 10 remaining items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)